### PR TITLE
Fix rust log format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
 
     std::env::set_var("RUST_LOG", "info");
-    env_logger::init();
+    log_init();
 
     let hub_did_topic = "nodex/did:nodex:test:EiCW6eklabBIrkTMHFpBln7574xmZlbMakWSCNtBWcunDg";
 
@@ -183,4 +183,35 @@ async fn main() -> std::io::Result<()> {
             panic!()
         }
     }
+}
+
+use env_logger::fmt::Color;
+use log::Level;
+
+fn log_init() {
+    let mut builder = env_logger::Builder::from_default_env();
+    builder.format(|buf, record| {
+        let level_color = match record.level() {
+            Level::Trace => Color::White,
+            Level::Debug => Color::Blue,
+            Level::Info => Color::Green,
+            Level::Warn => Color::Yellow,
+            Level::Error => Color::Red,
+        };
+        let mut level_style = buf.style();
+        level_style.set_color(level_color);
+
+        use std::io::Write;
+        writeln!(
+            buf,
+            "{} [{}] - {} - {} - {}:{}",
+            chrono::Local::now().format("%Y-%m-%dT%H:%M:%S"),
+            level_style.value(record.level()),
+            record.target(),
+            record.args(),
+            record.file().unwrap_or(""),
+            record.line().unwrap_or(0),
+        )
+    });
+    builder.init();
 }


### PR DESCRIPTION
Change rust log format

Before
```
warning: the following packages contain code that will be rejected by a future version of Rust: bigint v4.4.3, nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/nodex-agent`
[2023-05-24T08:13:10Z INFO  nodex_agent::nodex::extension::secure_keystore] Called: read_internal (type: Sign)
[2023-05-24T08:13:10Z INFO  nodex_agent::nodex::extension::secure_keystore] Called: read_internal (type: Update)
[2023-05-24T08:13:10Z INFO  nodex_agent::nodex::extension::secure_keystore] Called: read_internal (type: Recover)
[2023-05-24T08:13:10Z INFO  nodex_agent::nodex::extension::secure_keystore] Called: read_internal (type: Encrypt)
[2023-05-24T08:13:29Z INFO  nodex_agent] subscribed: nodex/did:nodex:test:EiCW6eklabBIrkTMHFpBln7574xmZlbMakWSCNtBWcunDg
[2023-05-24T08:13:29Z INFO  actix_server::builder] Starting 1 workers
[2023-05-24T08:13:29Z INFO  nodex_agent::handlers::sender] start sender
[2023-05-24T08:13:29Z INFO  nodex_agent::handlers::receiver] start receiver
[2023-05-24T08:13:29Z INFO  actix_server::server] Tokio runtime found; starting in existing Tokio runtime
[2023-05-24T08:13:29Z INFO  nodex_agent::handlers::receiver] stop receiver
```

After

```
warning: the following packages contain code that will be rejected by a future version of Rust: bigint v4.4.3, nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
     Running `target/debug/nodex-agent`
2023-05-24T17:30:00 [INFO] - nodex_agent::nodex::extension::secure_keystore - Called: read_internal (type: Sign) - src/nodex/extension/secure_keystore.rs:252
2023-05-24T17:30:00 [INFO] - nodex_agent::nodex::extension::secure_keystore - Called: read_internal (type: Update) - src/nodex/extension/secure_keystore.rs:252
2023-05-24T17:30:00 [INFO] - nodex_agent::nodex::extension::secure_keystore - Called: read_internal (type: Recover) - src/nodex/extension/secure_keystore.rs:252
2023-05-24T17:30:00 [INFO] - nodex_agent::nodex::extension::secure_keystore - Called: read_internal (type: Encrypt) - src/nodex/extension/secure_keystore.rs:252
2023-05-24T17:30:04 [INFO] - nodex_agent - subscribed: nodex/did:nodex:test:EiCW6eklabBIrkTMHFpBln7574xmZlbMakWSCNtBWcunDg - src/main.rs:146
2023-05-24T17:30:04 [INFO] - actix_server::builder - Starting 1 workers - /Users/dongri/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-server-2.1.1/src/builder.rs:200
2023-05-24T17:30:04 [INFO] - nodex_agent::handlers::receiver - start receiver - src/handlers/receiver.rs:17
2023-05-24T17:30:04 [INFO] - nodex_agent::handlers::sender - start sender - src/handlers/sender.rs:16
2023-05-24T17:30:04 [INFO] - actix_server::server - Tokio runtime found; starting in existing Tokio runtime - /Users/dongri/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-server-2.1.1/src/server.rs:197
2023-05-24T17:30:04 [INFO] - nodex_agent::handlers::receiver - stop receiver - src/handlers/receiver.rs:46
```

## File line numbers are now logged when an error occurs
Before
![Screenshot 2023-05-24 at 17 06 29](https://github.com/nodecross/nodex/assets/878993/89ad24b7-46e9-42cb-8553-750f43646947)

After
![Screenshot 2023-05-24 at 17 31 02](https://github.com/nodecross/nodex/assets/878993/2cb936dc-e1bb-4cbd-ac96-8080a18865f2)

