### PR TITLE
Save ProjectDID in network.json

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -170,20 +170,20 @@ async fn main() -> std::io::Result<()> {
 
     // NOTE: generate Key Chain
     let node_x = NodeX::new();
-    let did = node_x.create_identifier().await.unwrap();
+    let device_did = node_x.create_identifier().await.unwrap();
 
     // NOTE: CLI
     match cli.config {
         true => {
-            use_cli(cli.command, did.did_document.id.clone());
+            use_cli(cli.command, device_did.did_document.id.clone());
             return Ok(());
         }
         false => (),
     }
 
     // NOTE: hub initilize
-    hub_initilize(did.did_document.id.clone()).await;
-    send_device_info(did.did_document.id.clone()).await;
+    hub_initilize(device_did.did_document.id.clone()).await;
+    send_device_info(device_did.did_document.id.clone()).await;
 
     let sock_path = runtime_dir.clone().join("nodex.sock");
 
@@ -192,7 +192,7 @@ async fn main() -> std::io::Result<()> {
     let mqtt_port = 1883;
     let mqtt_client_id = cuid::cuid2();
 
-    let did_id = did.did_document.id;
+    let did_id = device_did.did_document.id;
     let mqtt_topic = format!("nodex/{}", did_id);
 
     let mut mqtt_options = MqttOptions::new(&mqtt_client_id, mqtt_host, mqtt_port);
@@ -263,7 +263,7 @@ async fn main() -> std::io::Result<()> {
 fn use_cli(command: Option<Commands>, did: String) {
     let mut network_config = Network::new();
     const SECRET_KEY: &str = "secret_key";
-    const PROJECT_ID: &str = "project_id";
+    const PROJECT_DID: &str = "project_did";
 
     if let Some(command) = command {
         match command {
@@ -276,9 +276,9 @@ fn use_cli(command: Option<Commands>, did: String) {
                         network_config.save_secretk_key(&value);
                         print!("Network {} is set", SECRET_KEY);
                     }
-                    PROJECT_ID => {
-                        network_config.save_project_id(&value);
-                        print!("Network {} is set", PROJECT_ID);
+                    PROJECT_DID => {
+                        network_config.save_project_did(&value);
+                        print!("Network {} is set", PROJECT_DID);
                     }
                     _ => {
                         print!("key is not found");
@@ -292,12 +292,12 @@ fn use_cli(command: Option<Commands>, did: String) {
                         };
                         print!("Network {} is not set", SECRET_KEY);
                     }
-                    PROJECT_ID => {
-                        if let Some(v) = network_config.get_project_id() {
-                            println!("Network {}: {}", PROJECT_ID, v);
+                    PROJECT_DID => {
+                        if let Some(v) = network_config.get_project_did() {
+                            println!("Network {}: {}", PROJECT_DID, v);
                             return;
                         };
-                        print!("Network {} is not set", PROJECT_ID);
+                        print!("Network {} is not set", PROJECT_DID);
                     }
                     _ => {
                         print!("key is not found");
@@ -308,9 +308,9 @@ fn use_cli(command: Option<Commands>, did: String) {
     }
 }
 
-async fn hub_initilize(did: String) {
+async fn hub_initilize(my_did: String) {
     let network_config = Network::new();
-    // NOTE: check network secret_key and project_id
+    // NOTE: check network secret_key and project_did
     match network_config.get_secretk_key() {
         Some(_) => (),
         None => {
@@ -318,10 +318,10 @@ async fn hub_initilize(did: String) {
             panic!()
         }
     }
-    match network_config.get_project_id() {
+    match network_config.get_project_did() {
         Some(_) => (),
         None => {
-            log::error!("Network project_id is not set. Please set project_id use cli");
+            log::error!("Network project_did is not set. Please set project_did use cli");
             panic!()
         }
     }
@@ -329,7 +329,7 @@ async fn hub_initilize(did: String) {
     // NOTE: register device
     let hub = Hub::new();
     match hub
-        .register_device(did, network_config.get_project_id().unwrap())
+        .register_device(my_did, network_config.get_project_did().unwrap())
         .await
     {
         Ok(()) => (),
@@ -340,7 +340,7 @@ async fn hub_initilize(did: String) {
     };
 }
 
-async fn send_device_info(did: String) {
+async fn send_device_info(device_did: String) {
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     const OS: &str = env::consts::OS;
     let mac_address: String = match get_mac_address() {
@@ -350,7 +350,7 @@ async fn send_device_info(did: String) {
 
     let hub = Hub::new();
     match hub
-        .send_device_info(did, mac_address, VERSION.to_string(), OS.to_string())
+        .send_device_info(device_did, mac_address, VERSION.to_string(), OS.to_string())
         .await
     {
         Ok(()) => (),

--- a/src/network.rs
+++ b/src/network.rs
@@ -14,7 +14,7 @@ use crate::nodex::errors::NodeXError;
 #[derive(Default)]
 pub struct ConfigNetwork {
     secret_key: Option<String>,
-    project_id: Option<String>,
+    project_did: Option<String>,
 }
 
 #[derive(Debug)]
@@ -99,13 +99,13 @@ impl Network {
         }
     }
 
-    // NOTE: project_id
-    pub fn get_project_id(&self) -> Option<String> {
-        self.root.project_id.clone()
+    // NOTE: project_did
+    pub fn get_project_did(&self) -> Option<String> {
+        self.root.project_did.clone()
     }
 
-    pub fn save_project_id(&mut self, value: &str) {
-        self.root.project_id = Some(value.to_string());
+    pub fn save_project_did(&mut self, value: &str) {
+        self.root.project_did = Some(value.to_string());
 
         match self.write() {
             Ok(_) => {}

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -15,7 +15,7 @@ pub struct Hub {
 #[derive(Debug, Serialize, Deserialize)]
 struct RegisterDeviceRequest {
     device_did: String,
-    project_id: String,
+    project_did: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -46,10 +46,14 @@ impl Hub {
         }
     }
 
-    pub async fn register_device(&self, did: String, project_id: String) -> Result<(), NodeXError> {
+    pub async fn register_device(
+        &self,
+        device_did: String,
+        project_did: String,
+    ) -> Result<(), NodeXError> {
         let request = RegisterDeviceRequest {
-            device_did: did,
-            project_id,
+            device_did,
+            project_did,
         };
         let payload = serde_json::to_string(&request).expect("failed to serialize");
         let res = match self.http_client.post("/v1/device", &payload).await {


### PR DESCRIPTION
## Description

`project_id` is the ID that should be only used in Hub. 
So, I removed `project_id` from network.json and added `project_did` alternatively.

## Check

Ensure that the word `project_id` does not exist in this repository.

```shell
nodex on  use-project-did [$!] via 🐳 desktop-linux is 📦 v1.1.12 via  v19.3.0 via 🦀 v1.70.0 via 🆂 on ☁️  (ap-northeast-1) 
❯ mdfind -onlyin . project_id
2023-09-19 01:43:52.292 mdfind[83034:34800141] [UserQueryParser] Loading keywords and predicates for locale "ja_JP"
2023-09-19 01:43:52.293 mdfind[83034:34800141] [UserQueryParser] Loading keywords and predicates for locale "ja"
```