### PR TITLE
feat: error handle status code for register device response

### DIFF
--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -94,15 +94,15 @@ impl Hub {
             },
             reqwest::StatusCode::BAD_REQUEST => {
                 log::error!("StatusCode=400, bad request");
-                return Err(NodeXError {});
+                Err(NodeXError {})
             }
             reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
                 log::error!("StatusCode=500, internal server error");
-                return Err(NodeXError {});
+                Err(NodeXError {})
             }
             other => {
                 log::error!("StatusCode={other}, unexpected response");
-                return Err(NodeXError {});
+                Err(NodeXError {})
             }
         }
     }

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -84,11 +84,25 @@ impl Hub {
                 return Err(NodeXError {});
             }
         };
-        match res.json::<EmptyResponse>().await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
+        match res.status() {
+            reqwest::StatusCode::OK => match res.json::<EmptyResponse>().await {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    log::error!("{:?}", e);
+                    Err(NodeXError {})
+                }
+            },
+            reqwest::StatusCode::BAD_REQUEST => {
+                log::error!("StatusCode=400, bad request");
+                return Err(NodeXError {});
+            }
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                log::error!("StatusCode=500, internal server error");
+                return Err(NodeXError {});
+            }
+            other => {
+                log::error!("StatusCode={other}, unexpected response");
+                return Err(NodeXError {});
             }
         }
     }


### PR DESCRIPTION
## Why

Currently, the error handle is not implemented and in any status code, the Agent will continue the process.
Therefore, I should fail and emit the error so that the executor can tell what failed.