### PR TITLE
feat: configure `event_at` for heart beat time

### DIFF
--- a/src/nodex/utils/hub_client.rs
+++ b/src/nodex/utils/hub_client.rs
@@ -1,5 +1,6 @@
 use crate::network_config;
 use crate::nodex::errors::NodeXError;
+use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use reqwest::{
     header::{HeaderMap, HeaderValue},
@@ -189,9 +190,11 @@ impl HubClient {
         path: &str,
         project_did: &str,
         is_active: bool,
+        event_at: DateTime<Utc>,
     ) -> Result<reqwest::Response, NodeXError> {
         let url = self.base_url.join(path);
         let payload = json!({
+            "event_at": event_at.to_rfc3339(),
             "is_healthy": is_active,
         });
         let payload = DIDCommEncryptedService::generate(project_did, &payload, None)

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -242,7 +242,12 @@ impl Hub {
         }
     }
 
-    pub async fn heartbeat(&self, project_did: &str, is_active: bool, event_at: DateTime<Utc>) -> Result<(), NodeXError> {
+    pub async fn heartbeat(
+        &self,
+        project_did: &str,
+        is_active: bool,
+        event_at: DateTime<Utc>,
+    ) -> Result<(), NodeXError> {
         let res = match self
             .http_client
             .heartbeat("/v1/heartbeat", project_did, is_active, event_at)

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -4,6 +4,7 @@ use crate::nodex::{
     utils::hub_client::{HubClient, HubClientConfig},
 };
 use crate::server_config;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize)]
@@ -241,10 +242,10 @@ impl Hub {
         }
     }
 
-    pub async fn heartbeat(&self, project_did: &str, is_active: bool) -> Result<(), NodeXError> {
+    pub async fn heartbeat(&self, project_did: &str, is_active: bool, event_at: DateTime<Utc>) -> Result<(), NodeXError> {
         let res = match self
             .http_client
-            .heartbeat("/v1/heartbeat", project_did, is_active)
+            .heartbeat("/v1/heartbeat", project_did, is_active, event_at)
             .await
         {
             Ok(v) => v,


### PR DESCRIPTION
## Why

Because it should tell the server "when" the heartbeat event happened.
Currently, there is no information about it, and the server has to use the processing or etc.