### PR TITLE
Fix asset path for example release to use the relative path

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -71,6 +71,6 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       with:
         upload_url: ${{ steps.release_drafter.outputs.upload_url }}
-        asset_path: /home/runner/ubuntu-latest/examples/nodejs/example.zip
+        asset_path: ./examples/nodejs/example.zip
         asset_name: example.zip
         asset_content_type: application/zip


### PR DESCRIPTION
## Why

Sorry, In the previous CI run [log](https://github.com/nodecross/nodex/actions/runs/6864576061/job/18667056390) the workflow failed, saying that the file doesn't exist. Thus, I'll fix this 🙏 