### PR TITLE
chore: Modify default value for NODEX_HUB_HTTP_ENDPOINT

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,3 @@
 NODEX_DID_HTTP_ENDPOINT=https://did.nodecross.io
 NODEX_DID_ATTACHMENT_LINK=https://did.getnodex.io
-NODEX_HUB_HTTP_ENDPOINT=http://hub.nodecross.io
+NODEX_HUB_HTTP_ENDPOINT=http://http.hub.nodecross.io

--- a/src/config.rs
+++ b/src/config.rs
@@ -452,8 +452,8 @@ impl ServerConfig {
             env::var("NODEX_DID_HTTP_ENDPOINT").unwrap_or("https://did.nodecross.io".to_string());
         let link =
             env::var("NODEX_DID_ATTACHMENT_LINK").unwrap_or("https://did.getnodex.io".to_string());
-        let hub_endpoint =
-            env::var("NODEX_HUB_HTTP_ENDPOINT").unwrap_or("https://hub.nodecross.io".to_string());
+        let hub_endpoint = env::var("NODEX_HUB_HTTP_ENDPOINT")
+            .unwrap_or("https://http.hub.nodecross.io".to_string());
 
         ServerConfig {
             did_http_endpoint: did_endpoint,


### PR DESCRIPTION
# Why
- Because we want to access the production Hub if we do not specify any environment variables