### PR TITLE
chore: bump version to `v1.2.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,7 +2540,7 @@ dependencies = [
 
 [[package]]
 name = "nodex"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nodex"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["NodeX Authors <>"]
 edition = "2018"
 license-file = "LICENSE"


### PR DESCRIPTION
## Why

We've forgotten to bump the version to this version in the latest release 🚀 