### PR TITLE
bump: cargo to `v1.2.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,7 +2540,7 @@ dependencies = [
 
 [[package]]
 name = "nodex"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nodex"
-version = "1.2.1"
+version = "1.2.2"
 authors = ["NodeX Authors <>"]
 edition = "2018"
 license-file = "LICENSE"


### PR DESCRIPTION
## Why

To release the next version 🚀 