### PR TITLE
fix: resort the example zip file entries and name the file `example.zip`

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -63,7 +63,7 @@ runs:
       working-directory: examples/nodejs
       run: |
         mv app/README.md .
-        zip -r app/ example.zip README.md package.json tsconfig.json yarn.lock ../../LICENSE
+        zip -r example.zip app/ README.md package.json tsconfig.json yarn.lock ../../LICENSE
 
     - name: (publish) upload asset (example)
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
## Why

Because the first argument is the file name... Sorry 🙏 
I messed up when I sorted it in my previous PR #206 