### PR TITLE
fix: ptr of CStr must use core::ffi::c_char

### DIFF
--- a/src/nodex/extension/secure_keystore.rs
+++ b/src/nodex/extension/secure_keystore.rs
@@ -222,20 +222,22 @@ impl SecureKeyStore {
                 ),
             };
 
-            let secret_key = match CStr::from_ptr(secret_key_buffer_ptr).to_str() {
-                Ok(v) => match hex::decode(v) {
-                    Ok(v) => v,
+            let secret_key =
+                match CStr::from_ptr(secret_key_buffer_ptr as *const core::ffi::c_char).to_str() {
+                    Ok(v) => match hex::decode(v) {
+                        Ok(v) => v,
+                        _ => return Err(NodeXError {}),
+                    },
                     _ => return Err(NodeXError {}),
-                },
-                _ => return Err(NodeXError {}),
-            };
-            let public_key = match CStr::from_ptr(public_key_buffer_ptr).to_str() {
-                Ok(v) => match hex::decode(v) {
-                    Ok(v) => v,
+                };
+            let public_key =
+                match CStr::from_ptr(public_key_buffer_ptr as *const core::ffi::c_char).to_str() {
+                    Ok(v) => match hex::decode(v) {
+                        Ok(v) => v,
+                        _ => return Err(NodeXError {}),
+                    },
                     _ => return Err(NodeXError {}),
-                },
-                _ => return Err(NodeXError {}),
-            };
+                };
 
             if result == 0 {
                 Ok(Some(KeyPair {

--- a/src/nodex/extension/trng.rs
+++ b/src/nodex/extension/trng.rs
@@ -49,7 +49,9 @@ impl Trng {
                 return Err(NodeXError {});
             }
 
-            Ok(CStr::from_ptr(buffer_ptr).to_bytes().to_vec())
+            Ok(CStr::from_ptr(buffer_ptr as *const core::ffi::c_char)
+                .to_bytes()
+                .to_vec())
         }
     }
 


### PR DESCRIPTION
## Why

The function `CStr::from_ptr` receives a pointer of `*const c_char`. The type `c_char` is depends on OS.

> On modern architectures this type will always be either [i8](https://doc.rust-lang.org/std/primitive.i8.html) or [u8](https://doc.rust-lang.org/std/primitive.u8.html), as they use byte-addresses memory with 8-bit bytes.
> https://doc.rust-lang.org/std/os/raw/type.c_char.html

In the MacOS environment, this code doesn't generate errors, but in linux it does.

## Check

I confirmed this by running ubuntu on an Apple silicon Mac.

Before running below command, I changed the example of the transfer to send message to itself.
```diff
diff --git a/examples/nodejs/cli/transfer.ts b/examples/nodejs/cli/transfer.ts
index 256aa05..38b1240 100644
--- a/examples/nodejs/cli/transfer.ts
+++ b/examples/nodejs/cli/transfer.ts
@@ -2,7 +2,7 @@ import { post } from './sock.js'
 
 (async () => {
   const json = await post('/transfer', {
-    destinations: [ 'did:nodex:test:EiBprXreMiba4loyl3psXm0RsECdtlCiQIjM8G9BtdQplA' ],
+    destinations: [ 'did:nodex:test:your-local-did' ],
     messages: [ {
       string: 'value',
       number: 1,
```

This is the command to run nodex and examples on ubuntu.
```
docker run --rm \
-v /path/to/your/home/.config:/root/.config \
-v `pwd`:/root/nodex \
--name arm-nodex \
-it rust:1.75.0-slim-bookworm

# in docker container
apt update && apt install -y build-essential
apt install -y nodejs npm
npm install -g yarn


cd /root/nodex/
cargo run

# in the other shell in docker container
docker exec -it arm-nodex /bin/bash
cd /root/nodex/examples/nodejs/

yarn transfer && yarn receive
```

nodex log
```
2024-01-06T12:26:07.738200797+00:00 [INFO] - nodex_agent::controllers::public::nodex_receive - Ok(HttpResponse { error: None, res: 
Response HTTP/1.1 101 Switching Protocols
  headers:
    "sec-websocket-accept": "7ce4EqjqlYNVzq3ePUjs7rMZkkU="
    "upgrade": "websocket"
  body: Stream
 }) - src/controllers/public/nodex_receive.rs:249
2024-01-06T12:26:07.738283422+00:00 [INFO] - nodex_agent::controllers::public::nodex_receive - Actor started - src/controllers/public/nodex_receive.rs:178
2024-01-06T12:26:08.195986172+00:00 [INFO] - nodex_agent::controllers::public::nodex_receive - Receive message. message_id = "36ca4bf9-7ff1-4e9c-ab0c-2ed10a550bb6" - src/controllers/public/nodex_receive.rs:109
2024-01-06T12:26:08.295924672+00:00 [INFO] - nodex_agent::controllers::public::nodex_receive - Verify success. message_id = 36ca4bf9-7ff1-4e9c-ab0c-2ed10a550bb6, from = did:nodex:test:EiBnYhFoNfHtFtssvceYUffF16sPxHk8YOl25z9uP2eSmA - src/controllers/public/nodex_receive.rs:112
2024-01-06T12:26:08.502397130+00:00 [INFO] - nodex_agent::controllers::public::nodex_receive - Ack message success : message_id = 36ca4bf9-7ff1-4e9c-ab0c-2ed10a550bb6 - src/controllers/public/nodex_receive.rs:168
```
