### PR TITLE
fix: change the version of forked version of didcomm-rs due to bugs in current version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -1201,9 +1201,8 @@ dependencies = [
 
 [[package]]
 name = "didcomm-rs"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d871ba34cbd28673062395a90964147db64e620d7df16cd57f4c3eac9188962"
+version = "0.8.0"
+source = "git+https://github.com/nodecross/didcomm-rs.git?tag=v0.8.0#b206c57b85165dec6e4e5a8f734b27ad5ef7befe"
 dependencies = [
  "aes-gcm",
  "arrayref",
@@ -2476,9 +2475,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -3035,7 +3034,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
- "regex-syntax",
+ "regex-syntax 0.6.27",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3219,13 +3218,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-automata",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3233,6 +3244,12 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "remove_dir_all"
@@ -4176,9 +4193,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom 0.2.7",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ scrypt = { version = "0.11.0", features = ["simple"] }
 aes-gcm-siv = { git = "https://github.com/RustCrypto/AEADs.git", tag = "aes-gcm-siv-v0.11.0-pre" }
 getrandom = { version = "0.2" }
 
-didcomm-rs = { version = "0.7.2" }
+didcomm-rs = { git = "https://github.com/nodecross/didcomm-rs.git", tag = "v0.8.0" }
 x25519-dalek = { version = "1.2.0" }
 
 reqwest = { version = "0.11", features = [

--- a/src/services/internal/didcomm_encrypted.rs
+++ b/src/services/internal/didcomm_encrypted.rs
@@ -95,10 +95,17 @@ impl DIDCommEncryptedService {
             }
         };
 
-        let mut message = Message::new()
+        let mut message = match Message::new()
             .from(&my_did)
             .to(&[to_did])
-            .body(&body.to_string());
+            .body(&body.to_string())
+        {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("Failed to initialize message. with error = {:?}", e);
+                return Err(NodeXError {});
+            }
+        };
 
         // NOTE: Has attachment
         if let Some(value) = metadata {
@@ -109,7 +116,7 @@ impl DIDCommEncryptedService {
                 .with_link(&attachment_link())
                 .with_json(&value.to_string());
 
-            message.apeend_attachment(
+            message.append_attachment(
                 AttachmentBuilder::new(true)
                     .with_id(&id)
                     .with_format("metadata")
@@ -241,7 +248,7 @@ impl DIDCommEncryptedService {
         };
 
         let metadata = message
-            .get_attachments()
+            .attachment_iter()
             .find(|item| match item.format.clone() {
                 Some(value) => value == "metadata",
                 None => false,

--- a/src/services/internal/didcomm_encrypted.rs
+++ b/src/services/internal/didcomm_encrypted.rs
@@ -102,7 +102,7 @@ impl DIDCommEncryptedService {
         {
             Ok(v) => v,
             Err(e) => {
-                log::error!("Failed to initialize message. with error = {:?}", e);
+                log::error!("Failed to initialize message with error = {:?}", e);
                 return Err(NodeXError {});
             }
         };

--- a/src/services/internal/didcomm_plaintext.rs
+++ b/src/services/internal/didcomm_plaintext.rs
@@ -46,7 +46,7 @@ impl DIDCommPlaintextService {
         {
             Ok(v) => v,
             Err(e) => {
-                log::error!("Failed to initialize message. with error = {:?}", e);
+                log::error!("Failed to initialize message with error = {:?}", e);
                 return Err(NodeXError {});
             }
         };

--- a/src/services/internal/didcomm_plaintext.rs
+++ b/src/services/internal/didcomm_plaintext.rs
@@ -39,10 +39,17 @@ impl DIDCommPlaintextService {
             }
         };
 
-        let mut message = Message::new()
+        let mut message = match Message::new()
             .from(&did)
             .to(&[to_did])
-            .body(&body.to_string());
+            .body(&body.to_string())
+        {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("Failed to initialize message. with error = {:?}", e);
+                return Err(NodeXError {});
+            }
+        };
 
         // NOTE: Has attachment
         if let Some(value) = metadata {
@@ -52,7 +59,7 @@ impl DIDCommPlaintextService {
                 .with_link(&attachment_link())
                 .with_json(&value.to_string());
 
-            message.apeend_attachment(
+            message.append_attachment(
                 AttachmentBuilder::new(true)
                     .with_id(&id)
                     .with_format("metadata")
@@ -85,7 +92,7 @@ impl DIDCommPlaintextService {
         };
 
         let metadata = message
-            .get_attachments()
+            .attachment_iter()
             .find(|item| match item.format.clone() {
                 Some(value) => value == "metadata",
                 None => false,

--- a/src/services/internal/didcomm_signed.rs
+++ b/src/services/internal/didcomm_signed.rs
@@ -44,10 +44,17 @@ impl DIDCommSignedService {
             }
         };
 
-        let mut message = Message::new()
+        let mut message = match Message::new()
             .from(&did)
             .to(&[to_did])
-            .body(&body.to_string());
+            .body(&body.to_string())
+        {
+            Ok(v) => v,
+            Err(e) => {
+                log::error!("Failed to initialize message. with error = {:?}", e);
+                return Err(NodeXError {});
+            }
+        };
 
         // NOTE: Has attachment
         if let Some(value) = metadata {
@@ -57,7 +64,7 @@ impl DIDCommSignedService {
                 .with_link(&attachment_link())
                 .with_json(&value.to_string());
 
-            message.apeend_attachment(
+            message.append_attachment(
                 AttachmentBuilder::new(true)
                     .with_id(&id)
                     .with_format("metadata")
@@ -154,7 +161,7 @@ impl DIDCommSignedService {
             };
 
         let metadata = message
-            .get_attachments()
+            .attachment_iter()
             .find(|item| match item.format.clone() {
                 Some(value) => value == "metadata",
                 None => false,

--- a/src/services/internal/didcomm_signed.rs
+++ b/src/services/internal/didcomm_signed.rs
@@ -51,7 +51,7 @@ impl DIDCommSignedService {
         {
             Ok(v) => v,
             Err(e) => {
-                log::error!("Failed to initialize message. with error = {:?}", e);
+                log::error!("Failed to initialize message with error = {:?}", e);
                 return Err(NodeXError {});
             }
         };


### PR DESCRIPTION
# What
- Changed to fork the latest version of https://github.com/decentralized-identity/didcomm-rs because there was a bug in the 0.7.2 version.

# Why
- Since https://github.com/decentralized-identity/didcomm-rs is not maintaining the situation, we decided to maintain it at nodecross
- Because the logic of the DID format check was incorrect
- https://github.com/decentralized-identity/didcomm-rs/blob/main/src/messages/helpers/encryption.rs#L385C6-L400

main
```
[a-zA-Z0-9.\-_%]+    # method specific identifier
```

0.7.2
```
[a-zA-Z0-9]+    # method specific identifier
```

