### PR TITLE
fix: stop using the action `upload-release-asset`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,11 +124,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload asset (example)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ inputs.github-token }}
+        uses: ./.github/actions/upload-release-asset
         with:
-          upload_url: ${{ steps.release_drafter.outputs.upload_url }}
+          release_id: ${{ steps.release.outputs.result }}
           asset_path: ./examples/nodejs/example.zip
           asset_name: example.zip
           asset_content_type: application/zip
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

- I redesigned the release workflow in this PR: https://github.com/nodecross/nodex/pull/217
- However, a mistake was made in uploading the examples.