### PR TITLE
chore: add the job to create a pr to update the version of Cargo.toml

### DIFF
--- a/.github/actions/check-team-affiliation-and-branch/action.yml
+++ b/.github/actions/check-team-affiliation-and-branch/action.yml
@@ -1,0 +1,36 @@
+name: Check Team affiliation and branch
+description: Check Team affiliation and Branch
+
+inputs:
+  ref:
+    required: true
+    description: ""
+  actor:
+    required: true
+    description: ""
+  github_token:
+    required: true
+    description: secret.GITHUB_TOKEN
+
+runs:
+  using: composite
+  steps:
+    - name: Stop workflow if not on main branch
+      if: ${{ inputs.ref != 'refs/heads/main' }}
+      run: |
+        echo "This job is only allowed to run on the main branch."
+        exit 1
+
+    - name: Check user for team affiliation
+      uses: tspascoal/get-user-teams-membership@v2
+      id: teamAffiliation
+      with:
+        GITHUB_TOKEN: ${{ input.github_token }}
+        username: ${{ github.actor }}
+        team: maintainer
+
+    - name: Stop workflow if user is no member
+      if: ${{ steps.teamAffiliation.outputs.isTeamMember == 'false' }}
+      run: |
+        echo "You have no rights to trigger this job."
+        exit 1

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,75 @@
+name: Bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: choice
+        required: true
+        description: "Major, minor or patch version bump"
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-user:
+    name: Check Team affiliation and Branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check Team affiliation and Branch
+        uses: ./.github/actions/check-team-affiliation-and-branch
+        with:
+          ref: ${{ github.ref }}
+          actor: ${{ github.actor }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  bump-version:
+    name: Bump Version
+    needs: check-user
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install `cargo-edit`
+        run: cargo install cargo-edit
+
+      - name: Install `cargo-get`
+        run: cargo install cargo-get
+
+      - id: cargo-set-version
+        name: Set Version
+        run: cargo set-version --bump ${{ inputs.version }}
+
+      - name: Set Crate Version as Environment Variable
+        id: set_crate_version
+        run: |
+          CARGO_TOML_VERSION=$(cargo get package.version)
+          echo "version=$CARGO_TOML_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create PR
+        id: create-pr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: bump version to v${{ steps.set_crate_version.outputs.version }}"
+          branch: "chore/bump-version-to-v${{ steps.set_crate_version.outputs.version }}"
+          delete-branch: true
+          title: "chore: bump version to v${{ steps.set_crate_version.outputs.version }}"
+          body: |
+            Bumps the version to v${{ steps.set_crate_version.outputs.version }}.
+
+            This PR was created by the [release workflow](${{ github.event.repository.html_url }}/actions/workflows/release.yml).
+
+            [release workflow]: ${{ github.event.repository.html_url }}/actions/workflows/release.yml
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,15 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        type: choice
+        required: true
+        description: "Major, minor or patch version bump"
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
@@ -132,3 +141,45 @@ jobs:
           asset_path: ./examples/nodejs/example.zip
           asset_name: example.zip
           asset_content_type: application/zip
+
+  bump-version:
+    name: Bump Version
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install `cargo-edit`
+        run: cargo install cargo-edit
+
+      - name: Install `cargo-get`
+        run: cargo install cargo-get
+
+      - id: cargo-set-version
+        name: Set Version
+        run: cargo set-version --bump ${{ inputs.version }}
+
+      - name: Set Crate Version as Environment Variable
+        id: set_crate_version
+        run: |
+          CARGO_TOML_VERSION=$(cargo get package.version)
+          echo "version=$CARGO_TOML_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create PR
+        id: create-pr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: bump version to v${{ steps.set_crate_version.outputs.version }}"
+          branch: "chore/bump-version-to-v${{ steps.set_crate_version.outputs.version }}"
+          delete-branch: true
+          title: "chore: bump version to v${{ steps.set_crate_version.outputs.version }}"
+          body: |
+            Bumps the version to v${{ steps.set_crate_version.outputs.version }}.
+
+            This PR was created by the [release workflow](${{ github.event.repository.html_url }}/actions/workflows/release.yml).
+
+            [release workflow]: ${{ github.event.repository.html_url }}/actions/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,45 +2,24 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        type: choice
-        required: true
-        description: "Major, minor or patch version bump"
-        options:
-          - patch
-          - minor
-          - major
 
 permissions:
   contents: write
-  issues: write
-  pull-requests: write
 
 jobs:
   check-user:
     name: Check Team affiliation and Branch
     runs-on: ubuntu-latest
     steps:
-      - name: Stop workflow if not on main branch
-        if: github.ref != 'refs/heads/main'
-        run: |
-          echo "This job is only allowed to run on the main branch."
-          exit 1
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Check user for team affiliation
-        uses: tspascoal/get-user-teams-membership@v2
-        id: teamAffiliation
+      - name: Check Team affiliation and Branch
+        uses: ./.github/actions/check-team-affiliation-and-branch
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          username: ${{ github.actor }}
-          team: maintainer
-
-      - name: Stop workflow if user is no member
-        if: ${{ steps.teamAffiliation.outputs.isTeamMember == 'false' }}
-        run: |
-          echo "You have no rights to trigger this job."
-          exit 1
+          ref: ${{ github.ref }}
+          actor: ${{ github.actor }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     name: Build
@@ -139,46 +118,4 @@ jobs:
           asset_path: ./examples/nodejs/example.zip
           asset_name: example.zip
           asset_content_type: application/zip
-
-  bump-version:
-    name: Bump Version
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install `cargo-edit`
-        run: cargo install cargo-edit
-
-      - name: Install `cargo-get`
-        run: cargo install cargo-get
-
-      - id: cargo-set-version
-        name: Set Version
-        run: cargo set-version --bump ${{ inputs.version }}
-
-      - name: Set Crate Version as Environment Variable
-        id: set_crate_version
-        run: |
-          CARGO_TOML_VERSION=$(cargo get package.version)
-          echo "version=$CARGO_TOML_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Create PR
-        id: create-pr
-        uses: peter-evans/create-pull-request@v5
-        with:
-          commit-message: "chore: bump version to v${{ steps.set_crate_version.outputs.version }}"
-          branch: "chore/bump-version-to-v${{ steps.set_crate_version.outputs.version }}"
-          delete-branch: true
-          title: "chore: bump version to v${{ steps.set_crate_version.outputs.version }}"
-          body: |
-            Bumps the version to v${{ steps.set_crate_version.outputs.version }}.
-
-            This PR was created by the [release workflow](${{ github.event.repository.html_url }}/actions/workflows/release.yml).
-
-            [release workflow]: ${{ github.event.repository.html_url }}/actions/workflows/release.yml
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

- Currently, We need to create the PR to update the version in Cargo.toml
- To reduce the operation, we want to automate it.

## What

- I've added the new job to create PR to update the version in Cargo.toml
  - To run only when a release is possible, the job is run after the Release job.

## Ref

- https://github.com/nodecross/nodecross/issues/17