### PR TITLE
feat: add proxy config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
 NODEX_DID_HTTP_ENDPOINT=https://did.nodecross.io
 NODEX_DID_ATTACHMENT_LINK=https://did.getnodex.io
 NODEX_HUB_HTTP_ENDPOINT=http://http.hub.nodecross.io
+NODEX_PROXY_ENDPOINT=

--- a/src/config.rs
+++ b/src/config.rs
@@ -486,9 +486,7 @@ impl Default for ProxyConfig {
 impl ProxyConfig {
     pub fn new() -> ProxyConfig {
         let proxy_endpoint = env::var("NODEX_PROXY_ENDPOINT").unwrap_or("".to_string());
-        ProxyConfig {
-            proxy_endpoint: proxy_endpoint,
-        }
+        ProxyConfig { proxy_endpoint }
     }
     pub fn proxy_endpoint(&self) -> String {
         self.proxy_endpoint.clone()

--- a/src/config.rs
+++ b/src/config.rs
@@ -471,3 +471,26 @@ impl ServerConfig {
         self.hub_http_endpoint.clone()
     }
 }
+
+#[derive(Debug)]
+pub struct ProxyConfig {
+    proxy_endpoint: String,
+}
+
+impl Default for ProxyConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProxyConfig {
+    pub fn new() -> ProxyConfig {
+        let proxy_endpoint = env::var("NODEX_PROXY_ENDPOINT").unwrap_or("".to_string());
+        ProxyConfig {
+            proxy_endpoint: proxy_endpoint,
+        }
+    }
+    pub fn proxy_endpoint(&self) -> String {
+        self.proxy_endpoint.clone()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 extern crate env_logger;
 
 use clap::{Parser, Subcommand};
+use config::ProxyConfig;
 use controllers::public::nodex_receive::ConnectionRepository;
 use rumqttc::{AsyncClient, MqttOptions, QoS};
 use services::hub::Hub;
@@ -81,6 +82,10 @@ pub fn network_config() -> Box<SingletonNetworkConfig> {
 
 pub fn server_config() -> ServerConfig {
     ServerConfig::new()
+}
+
+pub fn proxy_config() -> ProxyConfig {
+    ProxyConfig::new()
 }
 
 #[derive(Parser, Debug)]

--- a/src/nodex/utils/http_client.rs
+++ b/src/nodex/utils/http_client.rs
@@ -1,11 +1,12 @@
 use crate::nodex::errors::NodeXError;
 use reqwest::{
     header::{HeaderMap, HeaderValue},
-    Url,
+    Proxy, Url,
 };
 
 pub struct HttpClientConfig {
     pub base_url: String,
+    pub proxy: String,
 }
 
 #[derive(Clone, Debug)]
@@ -23,7 +24,7 @@ impl HttpClient {
                 return Err(NodeXError {});
             }
         };
-        let client: reqwest::Client = reqwest::Client::new();
+        let client = Self::build_client(&_config.proxy);
 
         Ok(HttpClient {
             instance: client,
@@ -38,6 +39,16 @@ impl HttpClient {
             HeaderValue::from_static("application/json"),
         );
         headers
+    }
+
+    fn build_client(proxy: &String) -> reqwest::Client {
+        if proxy.is_empty() {
+            return reqwest::Client::new();
+        }
+        reqwest::Client::builder()
+            .proxy(Proxy::all(proxy).unwrap())
+            .build()
+            .unwrap()
     }
 
     pub async fn get(&self, _path: &str) -> Result<reqwest::Response, NodeXError> {
@@ -131,6 +142,7 @@ pub mod tests {
     async fn it_should_success_get() {
         let client_config: HttpClientConfig = HttpClientConfig {
             base_url: "https://httpbin.org".to_string(),
+            proxy: "".to_string(),
         };
 
         let client = match HttpClient::new(&client_config) {
@@ -156,6 +168,7 @@ pub mod tests {
     async fn it_should_success_post() {
         let client_config: HttpClientConfig = HttpClientConfig {
             base_url: "https://httpbin.org".to_string(),
+            proxy: "".to_string(),
         };
 
         let client = match HttpClient::new(&client_config) {
@@ -181,6 +194,7 @@ pub mod tests {
     async fn it_should_success_put() {
         let client_config: HttpClientConfig = HttpClientConfig {
             base_url: "https://httpbin.org".to_string(),
+            proxy: "".to_string(),
         };
 
         let client = match HttpClient::new(&client_config) {
@@ -206,6 +220,7 @@ pub mod tests {
     async fn it_should_success_delete() {
         let client_config: HttpClientConfig = HttpClientConfig {
             base_url: "https://httpbin.org".to_string(),
+            proxy: "".to_string(),
         };
 
         let client = match HttpClient::new(&client_config) {

--- a/src/nodex/utils/hub_client.rs
+++ b/src/nodex/utils/hub_client.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use reqwest::{
     header::{HeaderMap, HeaderValue},
-    Url,
+    Proxy, Url,
 };
 use sha2::Sha256;
 
@@ -15,6 +15,7 @@ type HmacSha256 = Hmac<Sha256>;
 
 pub struct HubClientConfig {
     pub base_url: String,
+    pub proxy: String,
 }
 
 #[derive(Clone, Debug)]
@@ -32,12 +33,24 @@ impl HubClient {
                 return Err(NodeXError {});
             }
         };
-        let client: reqwest::Client = reqwest::Client::new();
+
+        let client = Self::build_client(&_config.proxy);
 
         Ok(HubClient {
             instance: client,
             base_url: url,
         })
+    }
+
+    fn build_client(proxy: &String) -> reqwest::Client {
+        if proxy.is_empty() {
+            return reqwest::Client::new();
+        }
+        reqwest::Client::builder()
+            .proxy(Proxy::all(proxy).unwrap())
+            .user_agent("NodeX Agent")
+            .build()
+            .unwrap()
     }
 
     fn auth_headers(&self, payload: String) -> Result<HeaderMap, NodeXError> {
@@ -291,6 +304,7 @@ pub mod tests {
     async fn it_should_success_get() {
         let client_config: HubClientConfig = HubClientConfig {
             base_url: "https://httpbin.org".to_string(),
+            proxy: "".to_string(),
         };
 
         let client = match HubClient::new(&client_config) {
@@ -316,6 +330,7 @@ pub mod tests {
     async fn it_should_success_post() {
         let client_config: HubClientConfig = HubClientConfig {
             base_url: "https://httpbin.org".to_string(),
+            proxy: "".to_string(),
         };
 
         let client = match HubClient::new(&client_config) {
@@ -341,6 +356,7 @@ pub mod tests {
     async fn it_should_success_put() {
         let client_config: HubClientConfig = HubClientConfig {
             base_url: "https://httpbin.org".to_string(),
+            proxy: "".to_string(),
         };
 
         let client = match HubClient::new(&client_config) {
@@ -366,6 +382,7 @@ pub mod tests {
     async fn it_should_success_delete() {
         let client_config: HubClientConfig = HubClientConfig {
             base_url: "https://httpbin.org".to_string(),
+            proxy: "".to_string(),
         };
 
         let client = match HubClient::new(&client_config) {

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -3,7 +3,7 @@ use crate::nodex::{
     errors::NodeXError,
     utils::hub_client::{HubClient, HubClientConfig},
 };
-use crate::server_config;
+use crate::{proxy_config, server_config};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -51,8 +51,10 @@ pub struct NetworkResponse {
 impl Hub {
     pub fn new() -> Self {
         let server_config = server_config();
+        let proxy_config = proxy_config();
         let client_config: HubClientConfig = HubClientConfig {
             base_url: server_config.hub_http_endpoint(),
+            proxy: proxy_config.proxy_endpoint(),
         };
 
         let client = match HubClient::new(&client_config) {

--- a/src/services/nodex.rs
+++ b/src/services/nodex.rs
@@ -7,7 +7,7 @@ use crate::nodex::{
     },
     utils::http_client::{HttpClient, HttpClientConfig},
 };
-use crate::server_config;
+use crate::{proxy_config, server_config};
 use serde_json::{json, Value};
 use std::{fs, process::Command};
 
@@ -18,8 +18,10 @@ pub struct NodeX {
 impl NodeX {
     pub fn new() -> Self {
         let server_config = server_config();
+        let proxy_config = proxy_config();
         let client_config: HttpClientConfig = HttpClientConfig {
             base_url: server_config.did_http_endpoint(),
+            proxy: proxy_config.proxy_endpoint(),
         };
 
         let client = match HttpClient::new(&client_config) {


### PR DESCRIPTION

## Why
A proxy may be present when sending outbound requests. However, this PR was created because requests are not currently sent through a proxy.

## What
- added the environment variable `NODEX_PROXY_ENDPOINT` 
- defined `ProxyConfig`
- added the use of ProxyConfig in HubClient and HttpClient.
  - added function "build_client" in HubClient and HttpClient to generate Client using the value of proxy.

## Check

I built a proxy (nginx) in my local environment and verified that I can send requests via proxy.
The following are the logs recorded by the proxy.
(I have temporarily set `NodeX` to the [user_agent of reqwest](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.user_agent) to make the logs easier to read.)

```
$ tail logs/access.log

127.0.0.1 - - [14/Jan/2024:19:23:19 +0900] "POST http://localhost:8000/v1/device HTTP/1.1" 200 2 "-" "NodeX" "-"
127.0.0.1 - - [14/Jan/2024:19:23:22 +0900] "POST http://localhost:8000/v1/device-info HTTP/1.1" 200 2 "-" "NodeX" "-"
127.0.0.1 - - [14/Jan/2024:19:23:23 +0900] "POST http://localhost:8000/v1/heartbeat HTTP/1.1" 200 2 "-" "NodeX" "-"
127.0.0.1 - - [14/Jan/2024:19:23:24 +0900] "POST http://localhost:8000/v1/message/list HTTP/1.1" 200 4064 "-" "NodeX " "-"
127.0.0.1 - - [14/Jan/2024:19:23:28 +0900] "POST http://localhost:8000/v1/message/list HTTP/1.1" 200 4064 "-" "NodeX " "-"
127.0.0.1 - - [14/Jan/2024:19:23:33 +0900] "POST http://localhost:8000/v1/message/list HTTP/1.1" 200 4064 "-" "NodeX " "-"
127.0.0.1 - - [14/Jan/2024:19:23:39 +0900] "POST http://localhost:8000/v1/message/list HTTP/1.1" 200 4064 "-" "NodeX " "-"
127.0.0.1 - - [14/Jan/2024:19:23:43 +0900] "POST http://localhost:8000/v1/message/list HTTP/1.1" 200 4064 "-" "NodeX " "-"

```


