### PR TITLE
feat: add custom error types for easy debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,6 +2579,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.2",
  "shadow-rs",
+ "thiserror",
  "tokio",
  "x25519-dalek",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,8 @@ shadow-rs = "0.21.0"
 dotenv = "0.15.0"
 mac_address = "1.1.5"
 
+thiserror = "1.0.30"
+
 [dev-dependencies]
 rstest = { version = "0.17.0" }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,24 +1,44 @@
 use home_config::HomeConfig;
 use serde::Deserialize;
 use serde::Serialize;
-use std::env;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io;
 use std::io::Write;
 use std::path::Path;
-
-use crate::nodex::errors::NodeXError;
+use std::{env, error::Error};
+use thiserror::Error;
 
 pub struct KeyPair {
     pub public_key: Vec<u8>,
     pub secret_key: Vec<u8>,
 }
 
+impl KeyPair {
+    fn to_keypair_config(&self) -> KeyPairConfig {
+        KeyPairConfig {
+            public_key: hex::encode(&self.public_key),
+            secret_key: hex::encode(&self.secret_key),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct KeyPairConfig {
     public_key: String,
     secret_key: String,
+}
+
+impl KeyPairConfig {
+    fn to_keypair(&self) -> Result<KeyPair, Box<dyn Error>> {
+        let pk = hex::decode(&self.public_key)?;
+        let sk = hex::decode(&self.secret_key)?;
+
+        Ok(KeyPair {
+            public_key: pk,
+            secret_key: sk,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -96,6 +116,14 @@ pub struct AppConfig {
     root: ConfigRoot,
 }
 
+#[derive(Error, Debug)]
+pub enum AppConfigError {
+    #[error("key decode failed")]
+    DecodeFailed(Box<dyn std::error::Error>),
+    #[error("failed to write config file")]
+    WriteError(home_config::JsonError),
+}
+
 impl AppConfig {
     fn touch(path: &Path) -> io::Result<()> {
         match OpenOptions::new().create(true).write(true).open(path) {
@@ -145,21 +173,13 @@ impl AppConfig {
         AppConfig { root, config }
     }
 
-    pub fn write(&self) -> Result<(), NodeXError> {
-        match self.config.save_json(&self.root) {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+    pub fn write(&self) -> Result<(), AppConfigError> {
+        self.config
+            .save_json(&self.root)
+            .map_err(AppConfigError::WriteError)
     }
 
-    pub fn encode(&self, value: &Option<Vec<u8>>) -> Option<String> {
-        value.as_ref().map(hex::encode)
-    }
-
-    pub fn decode(&self, value: &Option<String>) -> Option<Vec<u8>> {
+    fn decode(&self, value: &Option<String>) -> Option<Vec<u8>> {
         match value {
             Some(v) => match hex::decode(v) {
                 Ok(v) => Some(v),
@@ -216,94 +236,46 @@ impl AppConfig {
 
     // NOTE: SIGN
     pub fn load_sign_key_pair(&self) -> Option<KeyPair> {
-        match self.root.key_pairs.sign.clone() {
-            Some(v) => {
-                let pk = match self.decode(&Some(v.public_key)) {
-                    Some(v) => v,
-                    None => return None,
-                };
-                let sk = match self.decode(&Some(v.secret_key)) {
-                    Some(v) => v,
-                    None => return None,
-                };
-
-                Some(KeyPair {
-                    public_key: pk,
-                    secret_key: sk,
-                })
+        if let Some(ref key) = self.root.key_pairs.sign {
+            match Self::convert_to_key(key) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    log::error!("{:?}", e);
+                    None
+                }
             }
-            None => None,
+        } else {
+            None
         }
     }
 
-    pub fn save_sign_key_pair(&mut self, value: &KeyPair) -> Result<(), NodeXError> {
-        let pk = match self.encode(&Some(value.public_key.clone())) {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
-        let sk = match self.encode(&Some(value.secret_key.clone())) {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
+    fn convert_to_key(config: &KeyPairConfig) -> Result<KeyPair, AppConfigError> {
+        config.to_keypair().map_err(AppConfigError::DecodeFailed)
+    }
 
-        self.root.key_pairs.sign = Some(KeyPairConfig {
-            public_key: pk,
-            secret_key: sk,
-        });
-
-        match self.write() {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+    pub fn save_sign_key_pair(&mut self, value: &KeyPair) -> Result<(), AppConfigError> {
+        self.root.key_pairs.sign = Some(value.to_keypair_config());
+        self.write()
     }
 
     // NOTE: UPDATE
     pub fn load_update_key_pair(&self) -> Option<KeyPair> {
-        match self.root.key_pairs.update.clone() {
-            Some(v) => {
-                let pk = match self.decode(&Some(v.public_key)) {
-                    Some(v) => v,
-                    None => return None,
-                };
-                let sk = match self.decode(&Some(v.secret_key)) {
-                    Some(v) => v,
-                    None => return None,
-                };
-
-                Some(KeyPair {
-                    public_key: pk,
-                    secret_key: sk,
-                })
+        if let Some(ref key) = self.root.key_pairs.update {
+            match Self::convert_to_key(key) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    log::error!("{:?}", e);
+                    None
+                }
             }
-            None => None,
+        } else {
+            None
         }
     }
 
-    pub fn save_update_key_pair(&mut self, value: &KeyPair) -> Result<(), NodeXError> {
-        let pk = match self.encode(&Some(value.public_key.clone())) {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
-        let sk = match self.encode(&Some(value.secret_key.clone())) {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
-
-        self.root.key_pairs.update = Some(KeyPairConfig {
-            public_key: pk,
-            secret_key: sk,
-        });
-
-        match self.write() {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+    pub fn save_update_key_pair(&mut self, value: &KeyPair) -> Result<(), AppConfigError> {
+        self.root.key_pairs.update = Some(value.to_keypair_config());
+        self.write()
     }
 
     // NOTE: RECOVER
@@ -328,28 +300,9 @@ impl AppConfig {
         }
     }
 
-    pub fn save_recover_key_pair(&mut self, value: &KeyPair) -> Result<(), NodeXError> {
-        let pk = match self.encode(&Some(value.public_key.clone())) {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
-        let sk = match self.encode(&Some(value.secret_key.clone())) {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
-
-        self.root.key_pairs.recover = Some(KeyPairConfig {
-            public_key: pk,
-            secret_key: sk,
-        });
-
-        match self.write() {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+    pub fn save_recover_key_pair(&mut self, value: &KeyPair) -> Result<(), AppConfigError> {
+        self.root.key_pairs.recover = Some(value.to_keypair_config());
+        self.write()
     }
 
     // NOTE: ENCRYPT
@@ -374,28 +327,9 @@ impl AppConfig {
         }
     }
 
-    pub fn save_encrypt_key_pair(&mut self, value: &KeyPair) -> Result<(), NodeXError> {
-        let pk = match self.encode(&Some(value.public_key.clone())) {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
-        let sk = match self.encode(&Some(value.secret_key.clone())) {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
-
-        self.root.key_pairs.encrypt = Some(KeyPairConfig {
-            public_key: pk,
-            secret_key: sk,
-        });
-
-        match self.write() {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+    pub fn save_encrypt_key_pair(&mut self, value: &KeyPair) -> Result<(), AppConfigError> {
+        self.root.key_pairs.encrypt = Some(value.to_keypair_config());
+        self.write()
     }
 
     // NOTE: DID

--- a/src/nodex/extension/secure_keystore.rs
+++ b/src/nodex/extension/secure_keystore.rs
@@ -1,9 +1,9 @@
-use std::ffi::CStr;
+use std::{ffi::CStr, num::NonZeroU32};
+use thiserror::Error;
 
 use crate::{
     app_config,
     config::{Extension, KeyPair},
-    nodex::errors::NodeXError,
 };
 
 #[repr(C)]
@@ -22,6 +22,18 @@ pub enum SecureKeyStoreType {
     Encrypt,
 }
 
+#[derive(Error, Debug)]
+pub enum SecureKeyStoreError {
+    #[error("Library loading error")]
+    LibraryLoadingError(#[from] libloading::Error),
+    #[error("External function failed")]
+    ExternalFunctionFailed(NonZeroU32),
+    #[error("CStr convert failed")]
+    CStrConvertFailed(#[from] std::str::Utf8Error),
+    #[error("Hex decode failed")]
+    HexDecodeFailed(#[from] hex::FromHexError),
+}
+
 pub struct SecureKeyStore {}
 
 impl SecureKeyStore {
@@ -36,7 +48,7 @@ impl SecureKeyStore {
         extension: &Extension,
         key_type: &SecureKeyStoreType,
         key_pair: &KeyPair,
-    ) -> Result<(), NodeXError> {
+    ) -> Result<(), SecureKeyStoreError> {
         log::info!("Called: write_external (type: {:?})", key_type);
 
         unsafe {
@@ -48,13 +60,7 @@ impl SecureKeyStore {
             let secret_key_ptr: *const i8 = secret_key.as_ptr().cast();
             let public_key_ptr: *const i8 = public_key.as_ptr().cast();
 
-            let lib = match libloading::Library::new(&extension.filename) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+            let lib = libloading::Library::new(&extension.filename)?;
 
             let func: libloading::Symbol<
                 unsafe extern "C" fn(
@@ -64,13 +70,7 @@ impl SecureKeyStore {
                     secret_key_buffer_len: usize,
                     public_key_buffer_len: usize,
                 ) -> u32,
-            > = match lib.get(extension.symbol.as_bytes()) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+            > = lib.get(extension.symbol.as_bytes())?;
 
             let result = match key_type {
                 SecureKeyStoreType::Sign => func(
@@ -103,8 +103,8 @@ impl SecureKeyStore {
                 ),
             };
 
-            if result != 0 {
-                Err(NodeXError {})
+            if let Some(exit_status) = NonZeroU32::new(result) {
+                Err(SecureKeyStoreError::ExternalFunctionFailed(exit_status))
             } else {
                 Ok(())
             }
@@ -115,36 +115,28 @@ impl SecureKeyStore {
         &self,
         key_type: &SecureKeyStoreType,
         key_pair: &KeyPair,
-    ) -> Result<(), NodeXError> {
+    ) -> Result<(), SecureKeyStoreError> {
         log::info!("Called: write_internal (type: {:?})", key_type);
 
         let config = app_config();
+        let mut config = config.inner.lock().unwrap();
 
         match key_type {
-            SecureKeyStoreType::Sign => match config.inner.lock() {
-                Ok(mut config) => config.save_sign_key_pair(key_pair),
-                _ => Err(NodeXError {}),
-            },
-            SecureKeyStoreType::Update => match config.inner.lock() {
-                Ok(mut config) => config.save_update_key_pair(key_pair),
-                _ => Err(NodeXError {}),
-            },
-            SecureKeyStoreType::Recover => match config.inner.lock() {
-                Ok(mut config) => config.save_recover_key_pair(key_pair),
-                _ => Err(NodeXError {}),
-            },
-            SecureKeyStoreType::Encrypt => match config.inner.lock() {
-                Ok(mut config) => config.save_encrypt_key_pair(key_pair),
-                _ => Err(NodeXError {}),
-            },
+            SecureKeyStoreType::Sign => config.save_sign_key_pair(key_pair),
+            SecureKeyStoreType::Update => config.save_update_key_pair(key_pair),
+            SecureKeyStoreType::Recover => config.save_recover_key_pair(key_pair),
+            SecureKeyStoreType::Encrypt => config.save_encrypt_key_pair(key_pair),
         }
+        .expect("Failed to save key pair");
+
+        Ok(())
     }
 
     fn read_external(
         &self,
         extension: &Extension,
         key_type: &SecureKeyStoreType,
-    ) -> Result<Option<KeyPair>, NodeXError> {
+    ) -> Result<Option<KeyPair>, SecureKeyStoreError> {
         log::info!("Called: read_external (type: {:?})", key_type);
 
         unsafe {
@@ -157,13 +149,7 @@ impl SecureKeyStore {
             let secret_key_len = 0;
             let public_key_len = 0;
 
-            let lib = match libloading::Library::new(&extension.filename) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+            let lib = libloading::Library::new(&extension.filename)?;
 
             let func: libloading::Symbol<
                 unsafe extern "C" fn(
@@ -175,13 +161,7 @@ impl SecureKeyStore {
                     secret_key_len: *const usize,
                     public_key_len: *const usize,
                 ) -> u32,
-            > = match lib.get(extension.symbol.as_bytes()) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+            > = lib.get(extension.symbol.as_bytes())?;
 
             let result = match key_type {
                 SecureKeyStoreType::Sign => func(
@@ -222,56 +202,38 @@ impl SecureKeyStore {
                 ),
             };
 
-            let secret_key =
-                match CStr::from_ptr(secret_key_buffer_ptr as *const core::ffi::c_char).to_str() {
-                    Ok(v) => match hex::decode(v) {
-                        Ok(v) => v,
-                        _ => return Err(NodeXError {}),
-                    },
-                    _ => return Err(NodeXError {}),
-                };
-            let public_key =
-                match CStr::from_ptr(public_key_buffer_ptr as *const core::ffi::c_char).to_str() {
-                    Ok(v) => match hex::decode(v) {
-                        Ok(v) => v,
-                        _ => return Err(NodeXError {}),
-                    },
-                    _ => return Err(NodeXError {}),
-                };
+            unsafe fn to_hex_string(
+                buffer_ptr: *const core::ffi::c_char,
+            ) -> Result<Vec<u8>, SecureKeyStoreError> {
+                let str = CStr::from_ptr(buffer_ptr as *const core::ffi::c_char).to_str()?;
+                Ok(hex::decode(str)?)
+            }
 
-            if result == 0 {
+            let secret_key = to_hex_string(secret_key_buffer_ptr as *const core::ffi::c_char)?;
+            let public_key = to_hex_string(public_key_buffer_ptr as *const core::ffi::c_char)?;
+
+            if let Some(exit_status) = NonZeroU32::new(result) {
+                Err(SecureKeyStoreError::ExternalFunctionFailed(exit_status))
+            } else {
                 Ok(Some(KeyPair {
                     public_key,
                     secret_key,
                 }))
-            } else {
-                Err(NodeXError {})
             }
         }
     }
 
-    fn read_internal(&self, key_type: &SecureKeyStoreType) -> Result<Option<KeyPair>, NodeXError> {
+    fn read_internal(&self, key_type: &SecureKeyStoreType) -> Option<KeyPair> {
         log::debug!("Called: read_internal (type: {:?})", key_type);
 
         let config = app_config();
+        let config = config.inner.lock().unwrap();
 
         match key_type {
-            SecureKeyStoreType::Sign => match config.inner.lock() {
-                Ok(config) => Ok(config.load_sign_key_pair()),
-                _ => Err(NodeXError {}),
-            },
-            SecureKeyStoreType::Update => match config.inner.lock() {
-                Ok(config) => Ok(config.load_update_key_pair()),
-                _ => Err(NodeXError {}),
-            },
-            SecureKeyStoreType::Recover => match config.inner.lock() {
-                Ok(config) => Ok(config.load_recovery_key_pair()),
-                _ => Err(NodeXError {}),
-            },
-            SecureKeyStoreType::Encrypt => match config.inner.lock() {
-                Ok(config) => Ok(config.load_encrypt_key_pair()),
-                _ => Err(NodeXError {}),
-            },
+            SecureKeyStoreType::Sign => config.load_sign_key_pair(),
+            SecureKeyStoreType::Update => config.load_update_key_pair(),
+            SecureKeyStoreType::Recover => config.load_recovery_key_pair(),
+            SecureKeyStoreType::Encrypt => config.load_encrypt_key_pair(),
         }
     }
 
@@ -279,12 +241,10 @@ impl SecureKeyStore {
         &self,
         key_type: &SecureKeyStoreType,
         key_pair: &KeyPair,
-    ) -> Result<(), NodeXError> {
+    ) -> Result<(), SecureKeyStoreError> {
         let config = app_config();
-        let extension = match config.inner.lock() {
-            Ok(config) => config.load_secure_keystore_write_sig(),
-            _ => return Err(NodeXError {}),
-        };
+        let config = config.inner.lock().unwrap();
+        let extension = config.load_secure_keystore_write_sig();
 
         match extension {
             Some(v) => self.write_external(&v, key_type, key_pair),
@@ -292,16 +252,17 @@ impl SecureKeyStore {
         }
     }
 
-    pub fn read(&self, key_type: &SecureKeyStoreType) -> Result<Option<KeyPair>, NodeXError> {
+    pub fn read(
+        &self,
+        key_type: &SecureKeyStoreType,
+    ) -> Result<Option<KeyPair>, SecureKeyStoreError> {
         let config = app_config();
-        let extension = match config.inner.lock() {
-            Ok(config) => config.load_secure_keystore_read_sig(),
-            _ => return Err(NodeXError {}),
-        };
+        let config = config.inner.lock().unwrap();
+        let extension = config.load_secure_keystore_read_sig();
 
         match extension {
             Some(v) => self.read_external(&v, key_type),
-            _ => self.read_internal(key_type),
+            _ => Ok(self.read_internal(key_type)),
         }
     }
 }

--- a/src/nodex/extension/trng.rs
+++ b/src/nodex/extension/trng.rs
@@ -1,11 +1,21 @@
-use crate::{
-    app_config,
-    config::Extension,
-    nodex::{errors::NodeXError, runtime::random::Random},
-};
-use std::ffi::CStr;
+use crate::{app_config, config::Extension, nodex::runtime::random::Random};
+use std::{ffi::CStr, num::NonZeroU32};
+
+use thiserror::Error;
 
 pub struct Trng {}
+
+#[derive(Error, Debug)]
+pub enum TrngError {
+    #[error("Buffer length over")]
+    BufferLengthOver,
+    #[error("Library loading error")]
+    LibraryLoadingError(#[from] libloading::Error),
+    #[error("External function failed")]
+    ExternalFunctionFailed(NonZeroU32),
+    #[error("Random generation failed")]
+    RandomGenerationFailed(Box<dyn std::error::Error>),
+}
 
 impl Trng {
     const MAX_BUFFER_LENGTH: usize = 1024;
@@ -14,39 +24,27 @@ impl Trng {
         Trng {}
     }
 
-    fn read_external(&self, extension: &Extension, size: &usize) -> Result<Vec<u8>, NodeXError> {
+    fn read_external(&self, extension: &Extension, size: &usize) -> Result<Vec<u8>, TrngError> {
         log::info!("Called: read_external");
 
         if Trng::MAX_BUFFER_LENGTH < *size {
-            return Err(NodeXError {});
+            return Err(TrngError::BufferLengthOver);
         }
 
         unsafe {
             let buffer = [0u8; Trng::MAX_BUFFER_LENGTH + 1];
             let buffer_ptr: *const i8 = buffer.as_ptr().cast();
 
-            let lib = match libloading::Library::new(&extension.filename) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+            let lib = libloading::Library::new(&extension.filename)?;
 
             let func: libloading::Symbol<
                 unsafe extern "C" fn(buf: *const i8, bufsize: usize, size: usize) -> u32,
-            > = match lib.get(extension.symbol.as_bytes()) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+            > = lib.get(extension.symbol.as_bytes())?;
 
             let result = func(buffer_ptr, buffer.len(), *size);
 
-            if result != 0 {
-                return Err(NodeXError {});
+            if let Some(exit_status) = NonZeroU32::new(result) {
+                return Err(TrngError::ExternalFunctionFailed(exit_status));
             }
 
             Ok(CStr::from_ptr(buffer_ptr as *const core::ffi::c_char)
@@ -55,22 +53,20 @@ impl Trng {
         }
     }
 
-    fn read_internal(&self, size: &usize) -> Result<Vec<u8>, NodeXError> {
+    fn read_internal(&self, size: &usize) -> Result<Vec<u8>, TrngError> {
         log::info!("Called: read_internal");
 
-        Random::bytes(size)
+        Random::bytes(size).map_err(TrngError::RandomGenerationFailed)
     }
 
-    pub fn read(&self, size: &usize) -> Result<Vec<u8>, NodeXError> {
+    pub fn read(&self, size: &usize) -> Result<Vec<u8>, TrngError> {
         let config = app_config();
-        let extension = match config.inner.lock() {
-            Ok(config) => config.load_trng_read_sig(),
-            _ => return Err(NodeXError {}),
-        };
+        let config = config.inner.lock().unwrap();
 
-        match extension {
-            Some(v) => self.read_external(&v, size),
-            _ => self.read_internal(size),
+        if let Some(ref extension) = config.load_trng_read_sig() {
+            self.read_external(extension, size)
+        } else {
+            self.read_internal(size)
         }
     }
 }

--- a/src/nodex/keyring/keypair.rs
+++ b/src/nodex/keyring/keypair.rs
@@ -1,15 +1,16 @@
-use super::secp256k1::{Secp256k1, Secp256k1Context};
+use super::secp256k1::{Secp256k1, Secp256k1Context, Secp256k1Error};
 use crate::{
     app_config,
     config::KeyPair,
     nodex::{
-        errors::NodeXError,
         extension::secure_keystore::{SecureKeyStore, SecureKeyStoreType},
-        extension::trng::Trng,
+        extension::{secure_keystore::SecureKeyStoreError, trng::Trng},
         runtime,
     },
     SingletonAppConfig,
 };
+
+use thiserror::Error;
 
 pub struct KeyPairing {
     sign: Secp256k1,
@@ -20,64 +21,51 @@ pub struct KeyPairing {
     secure_keystore: SecureKeyStore,
 }
 
+#[derive(Error, Debug)]
+pub enum KeyPairingError {
+    #[error("secure keystore error")]
+    SecureKeyStoreError(#[from] SecureKeyStoreError),
+    #[error("key not found")]
+    KeyNotFound,
+    #[error("secp256k1 error")]
+    KeyInitializationError(#[from] Secp256k1Error),
+    #[error("Trng error")]
+    TrngError(#[from] crate::nodex::extension::trng::TrngError),
+    #[error("BIP32 error")]
+    BIP32Error(#[from] runtime::bip32::BIP32Error),
+    #[error("DID not found")]
+    DIDNotFound,
+}
+
 impl KeyPairing {
     const SIGN_DERIVATION_PATH: &'static str = "m/44'/0'/0'/0/10";
     const UPDATE_DERIVATION_PATH: &'static str = "m/44'/0'/0'/0/20";
     const RECOVERY_DERIVATION_PATH: &'static str = "m/44'/0'/0'/0/30";
     const ENCRYPT_DERIVATION_PATH: &'static str = "m/44'/0'/0'/0/40";
 
-    pub fn load_keyring() -> Result<Self, NodeXError> {
+    pub fn load_keyring() -> Result<Self, KeyPairingError> {
         let config = app_config();
         let secure_keystore = SecureKeyStore::new();
 
-        let sign = match secure_keystore.read(&SecureKeyStoreType::Sign) {
-            Ok(Some(v)) => {
-                match Secp256k1::new(&Secp256k1Context {
-                    public: v.public_key,
-                    secret: v.secret_key,
-                }) {
-                    Ok(v) => v,
-                    _ => return Err(NodeXError {}),
-                }
-            }
-            _ => return Err(NodeXError {}),
-        };
-        let update = match secure_keystore.read(&SecureKeyStoreType::Update) {
-            Ok(Some(v)) => {
-                match Secp256k1::new(&Secp256k1Context {
-                    public: v.public_key,
-                    secret: v.secret_key,
-                }) {
-                    Ok(v) => v,
-                    _ => return Err(NodeXError {}),
-                }
-            }
-            _ => return Err(NodeXError {}),
-        };
-        let recovery = match secure_keystore.read(&SecureKeyStoreType::Recover) {
-            Ok(Some(v)) => {
-                match Secp256k1::new(&Secp256k1Context {
-                    public: v.public_key,
-                    secret: v.secret_key,
-                }) {
-                    Ok(v) => v,
-                    _ => return Err(NodeXError {}),
-                }
-            }
-            _ => return Err(NodeXError {}),
-        };
-        let encrypt = match secure_keystore.read(&SecureKeyStoreType::Encrypt) {
-            Ok(Some(v)) => {
-                match Secp256k1::new(&Secp256k1Context {
-                    public: v.public_key,
-                    secret: v.secret_key,
-                }) {
-                    Ok(v) => v,
-                    _ => return Err(NodeXError {}),
-                }
-            }
-            _ => return Err(NodeXError {}),
-        };
+        fn load_secp256k1(
+            secure_keystore: &SecureKeyStore,
+            key_type: SecureKeyStoreType,
+        ) -> Result<Secp256k1, KeyPairingError> {
+            let key_pair = secure_keystore
+                .read(&key_type)?
+                .ok_or(KeyPairingError::KeyNotFound)?;
+
+            Secp256k1::new(&Secp256k1Context {
+                public: key_pair.public_key,
+                secret: key_pair.secret_key,
+            })
+            .map_err(KeyPairingError::KeyInitializationError)
+        }
+
+        let sign = load_secp256k1(&secure_keystore, SecureKeyStoreType::Sign)?;
+        let update = load_secp256k1(&secure_keystore, SecureKeyStoreType::Update)?;
+        let recovery = load_secp256k1(&secure_keystore, SecureKeyStoreType::Recover)?;
+        let encrypt = load_secp256k1(&secure_keystore, SecureKeyStoreType::Encrypt)?;
 
         Ok(KeyPairing {
             sign,
@@ -89,48 +77,18 @@ impl KeyPairing {
         })
     }
 
-    pub fn create_keyring() -> Result<Self, NodeXError> {
+    pub fn create_keyring() -> Result<Self, KeyPairingError> {
         let config = app_config();
         let secure_keystore = SecureKeyStore::new();
 
         let trng = Trng::new();
 
-        let seed = match trng.read(&(256 / 8)) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let seed = trng.read(&(256 / 8))?;
 
-        let sign = match Self::generate_secp256k1(&seed, Self::SIGN_DERIVATION_PATH) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let update = match Self::generate_secp256k1(&seed, Self::UPDATE_DERIVATION_PATH) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let recovery = match Self::generate_secp256k1(&seed, Self::RECOVERY_DERIVATION_PATH) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let encrypt = match Self::generate_secp256k1(&seed, Self::ENCRYPT_DERIVATION_PATH) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let sign = Self::generate_secp256k1(&seed, Self::SIGN_DERIVATION_PATH)?;
+        let update = Self::generate_secp256k1(&seed, Self::UPDATE_DERIVATION_PATH)?;
+        let recovery = Self::generate_secp256k1(&seed, Self::RECOVERY_DERIVATION_PATH)?;
+        let encrypt = Self::generate_secp256k1(&seed, Self::ENCRYPT_DERIVATION_PATH)?;
 
         Ok(KeyPairing {
             sign,
@@ -158,25 +116,17 @@ impl KeyPairing {
         self.encrypt.clone()
     }
 
-    pub fn generate_secp256k1(seed: &[u8], derivation_path: &str) -> Result<Secp256k1, NodeXError> {
-        let node = match runtime::bip32::BIP32::get_node(seed, derivation_path) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn generate_secp256k1(
+        seed: &[u8],
+        derivation_path: &str,
+    ) -> Result<Secp256k1, KeyPairingError> {
+        let node = runtime::bip32::BIP32::get_node(seed, derivation_path)?;
 
-        match Secp256k1::new(&Secp256k1Context {
+        Secp256k1::new(&Secp256k1Context {
             public: node.public_key,
             secret: node.private_key,
-        }) {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+        })
+        .map_err(KeyPairingError::KeyInitializationError)
     }
 
     pub fn save(&mut self, did: &str) {
@@ -221,26 +171,18 @@ impl KeyPairing {
             _ => panic!(),
         };
 
-        match self.config.inner.lock() {
-            Ok(mut config) => config.save_did(did),
-            _ => panic!(),
-        };
-
-        match self.config.inner.lock() {
-            Ok(mut config) => {
-                config.save_is_initialized(true);
-            }
-            _ => panic!(),
-        }
+        let mut config = self.config.inner.lock().unwrap();
+        config.save_did(did);
+        config.save_is_initialized(true);
     }
 
-    pub fn get_identifier(&self) -> Result<String, NodeXError> {
-        let did = self.config.inner.lock().unwrap().get_did();
-
-        match did {
-            Some(v) => Ok(v),
-            None => Err(NodeXError {}),
-        }
+    pub fn get_identifier(&self) -> Result<String, KeyPairingError> {
+        self.config
+            .inner
+            .lock()
+            .unwrap()
+            .get_did()
+            .ok_or(KeyPairingError::DIDNotFound)
     }
 }
 

--- a/src/nodex/keyring/secp256k1.rs
+++ b/src/nodex/keyring/secp256k1.rs
@@ -1,11 +1,11 @@
 use crate::nodex::runtime;
+use crate::nodex::runtime::base64_url::PaddingType;
 use crate::nodex::sidetree::payload::PublicKeyPayload;
-use crate::nodex::{errors::NodeXError, runtime::base64_url::PaddingType};
 use hex;
 use ibig::{ibig, IBig};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::u8;
+use thiserror::Error;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeyPairSecp256K1 {
@@ -45,39 +45,49 @@ pub struct Secp256k1 {
     private: Vec<u8>,
 }
 
+#[derive(Error, Debug)]
+pub enum Secp256k1Error {
+    #[error("Invalid public key size")]
+    InvalidSecretKeySize,
+    #[error("Secp256k1 runtime error")]
+    Secp256k1RuntimeError(#[from] runtime::secp256k1::Secp256k1Error),
+    #[error("Invalid public key size")]
+    InvalidPublicKeySize,
+    #[error("Base64 decode error")]
+    Base64UrlError(#[from] runtime::base64_url::Base64UrlError),
+    #[error("Invalid first bytes")]
+    InvalidFirstBytes,
+    #[error("Number parsing error")]
+    NumberParsingError(#[from] ibig::error::ParseError),
+    #[error("Validation Failed")]
+    ValidationFailed,
+}
+
 impl Secp256k1 {
     const PRIVATE_KEY_SIZE: usize = 32; // Buffer(PrivateKey (32 = 256 bit))
     const COMPRESSED_PUBLIC_KEY_SIZE: usize = 33; // Buffer(0x04 + PublicKey (32 = 256 bit))
     const UNCOMPRESSED_PUBLIC_KEY_SIZE: usize = 65; // Buffer(0x04 + PublicKey (64 = 512 bit))
 
-    pub fn new(context: &Secp256k1Context) -> Result<Self, NodeXError> {
+    pub fn new(context: &Secp256k1Context) -> Result<Self, Secp256k1Error> {
         if context.secret.len() != Self::PRIVATE_KEY_SIZE {
-            return Err(NodeXError {});
+            return Err(Secp256k1Error::InvalidSecretKeySize);
         }
 
         if context.public.len() == Self::COMPRESSED_PUBLIC_KEY_SIZE {
-            let public = match Secp256k1::transform_uncompressed_public_key(&context.public) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+            let public = Secp256k1::transform_uncompressed_public_key(&context.public)?;
 
-            return Ok(Secp256k1 {
+            Ok(Secp256k1 {
                 public,
                 private: context.secret.clone(),
-            });
-        }
-
-        if context.public.len() == Self::UNCOMPRESSED_PUBLIC_KEY_SIZE {
-            return Ok(Secp256k1 {
+            })
+        } else if context.public.len() == Self::UNCOMPRESSED_PUBLIC_KEY_SIZE {
+            Ok(Secp256k1 {
                 public: context.public.clone(),
                 private: context.secret.clone(),
-            });
+            })
+        } else {
+            Err(Secp256k1Error::InvalidPublicKeySize)
         }
-
-        Err(NodeXError {})
     }
 
     pub fn get_public_key(&self) -> Vec<u8> {
@@ -96,7 +106,7 @@ impl Secp256k1 {
         }
     }
 
-    pub fn from_jwk(jwk: &KeyPairSecp256K1) -> Result<Self, NodeXError> {
+    pub fn from_jwk(jwk: &KeyPairSecp256K1) -> Result<Self, Secp256k1Error> {
         let d = match jwk.d.clone() {
             Some(v) => v,
             None => {
@@ -105,67 +115,24 @@ impl Secp256k1 {
             }
         };
 
-        let x = match runtime::base64_url::Base64Url::decode_as_bytes(
-            &jwk.x,
-            &PaddingType::NoPadding,
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let y = match runtime::base64_url::Base64Url::decode_as_bytes(
-            &jwk.y,
-            &PaddingType::NoPadding,
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let x = runtime::base64_url::Base64Url::decode_as_bytes(&jwk.x, &PaddingType::NoPadding)?;
+        let y = runtime::base64_url::Base64Url::decode_as_bytes(&jwk.y, &PaddingType::NoPadding)?;
 
         let public = [&[0x04], &x[..], &y[..]].concat();
-        let private =
-            match runtime::base64_url::Base64Url::decode_as_bytes(&d, &PaddingType::NoPadding) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+        let private = runtime::base64_url::Base64Url::decode_as_bytes(&d, &PaddingType::NoPadding)?;
 
         Ok(Secp256k1 { public, private })
     }
 
-    pub fn to_jwk(&self, included_private_key: bool) -> Result<KeyPairSecp256K1, NodeXError> {
-        let validated = match self.validate_point() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn to_jwk(&self, included_private_key: bool) -> Result<KeyPairSecp256K1, Secp256k1Error> {
+        let validated = self.validate_point()?;
 
         if !validated {
-            return Err(NodeXError {});
+            return Err(Secp256k1Error::ValidationFailed);
         }
 
-        let x = match self.get_point_x() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let y = match self.get_point_y() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let x = self.get_point_x()?;
+        let y = self.get_point_y()?;
 
         if included_private_key {
             Ok(KeyPairSecp256K1 {
@@ -195,26 +162,14 @@ impl Secp256k1 {
         &self,
         key_id: &str,
         purpose: &[&str],
-    ) -> Result<PublicKeyPayload, NodeXError> {
-        let validated = match self.validate_point() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    ) -> Result<PublicKeyPayload, Secp256k1Error> {
+        let validated = self.validate_point()?;
 
         if !validated {
-            return Err(NodeXError {});
+            return Err(Secp256k1Error::ValidationFailed);
         }
 
-        let jwk = match self.to_jwk(false) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let jwk = self.to_jwk(false)?;
 
         Ok(PublicKeyPayload {
             id: key_id.to_string(),
@@ -228,14 +183,14 @@ impl Secp256k1 {
         })
     }
 
-    pub fn get_point_x(&self) -> Result<Vec<u8>, NodeXError> {
+    pub fn get_point_x(&self) -> Result<Vec<u8>, Secp256k1Error> {
         let public = self.get_public_key();
 
         if public.len() != Self::UNCOMPRESSED_PUBLIC_KEY_SIZE {
-            return Err(NodeXError {});
+            return Err(Secp256k1Error::InvalidPublicKeySize);
         }
         if public[0] != 0x04 {
-            return Err(NodeXError {});
+            return Err(Secp256k1Error::InvalidFirstBytes);
         }
 
         let (_, n) = public.split_at(1);
@@ -244,14 +199,14 @@ impl Secp256k1 {
         Ok(s.to_vec())
     }
 
-    pub fn get_point_y(&self) -> Result<Vec<u8>, NodeXError> {
+    pub fn get_point_y(&self) -> Result<Vec<u8>, Secp256k1Error> {
         let public = self.get_public_key();
 
         if public.len() != Self::UNCOMPRESSED_PUBLIC_KEY_SIZE {
-            return Err(NodeXError {});
+            return Err(Secp256k1Error::InvalidPublicKeySize);
         }
         if public[0] != 0x04 {
-            return Err(NodeXError {});
+            return Err(Secp256k1Error::InvalidFirstBytes);
         }
 
         let (_, n) = public.split_at(1);
@@ -260,54 +215,24 @@ impl Secp256k1 {
         Ok(s.to_vec())
     }
 
-    pub fn validate_point(&self) -> Result<bool, NodeXError> {
-        let x = match self.get_point_x() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let y = match self.get_point_y() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn validate_point(&self) -> Result<bool, Secp256k1Error> {
+        let x = self.get_point_x()?;
+        let y = self.get_point_y()?;
 
-        let nx = match IBig::from_str_radix(&hex::encode(x), 16) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let ny = match IBig::from_str_radix(&hex::encode(y), 16) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let np = match IBig::from_str_radix(
+        let nx = IBig::from_str_radix(&hex::encode(x), 16)?;
+        let ny = IBig::from_str_radix(&hex::encode(y), 16)?;
+        let np = IBig::from_str_radix(
             "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
             16,
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        )?;
 
         let verified: IBig = (&ny * &ny - &nx * &nx * &nx - 7) % &np;
 
         Ok(verified.cmp(&ibig!(0)) == Ordering::Equal)
     }
 
-    pub fn transform_uncompressed_public_key(compressed: &[u8]) -> Result<Vec<u8>, NodeXError> {
-        runtime::secp256k1::Secp256k1::convert_public_key(compressed, false)
+    pub fn transform_uncompressed_public_key(compressed: &[u8]) -> Result<Vec<u8>, Secp256k1Error> {
+        runtime::secp256k1::Secp256k1::convert_public_key(compressed, false).map_err(|e| e.into())
     }
 }
 

--- a/src/nodex/runtime/aes_gcm_siv.rs
+++ b/src/nodex/runtime/aes_gcm_siv.rs
@@ -1,41 +1,49 @@
-use crate::nodex::errors::NodeXError;
 use aes_gcm_siv::aead::{Aead, NewAead};
 use aes_gcm_siv::{Aes256GcmSiv, Key, Nonce};
+use thiserror::Error;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct AesGcmSiv {}
 
+#[derive(Error, Debug)]
+pub enum AesGcmSivError {
+    #[error("encrypt failed : {0:?}")]
+    EncryptFailed(aes_gcm_siv::aead::Error),
+    #[error("decrypt failed : {0:?}")]
+    DecryptFailed(aes_gcm_siv::aead::Error),
+}
+
 impl AesGcmSiv {
     #[allow(dead_code)]
-    pub fn encrypt(_key: &[u8], _nonce: &[u8], _plain_text: &[u8]) -> Result<Vec<u8>, NodeXError> {
+    pub fn encrypt(
+        _key: &[u8],
+        _nonce: &[u8],
+        _plain_text: &[u8],
+    ) -> Result<Vec<u8>, AesGcmSivError> {
         let key = Key::from_slice(_key);
         let nonce = Nonce::from_slice(_nonce);
 
         let cipher = Aes256GcmSiv::new(key);
 
-        match cipher.encrypt(nonce, _plain_text) {
-            Ok(v) => Ok(v.to_vec()),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+        cipher
+            .encrypt(nonce, _plain_text)
+            .map_err(AesGcmSivError::EncryptFailed)
     }
 
     #[allow(dead_code)]
-    pub fn decrypt(_key: &[u8], _nonce: &[u8], _cipher_text: &[u8]) -> Result<Vec<u8>, NodeXError> {
+    pub fn decrypt(
+        _key: &[u8],
+        _nonce: &[u8],
+        _cipher_text: &[u8],
+    ) -> Result<Vec<u8>, AesGcmSivError> {
         let key = Key::from_slice(_key);
         let nonce = Nonce::from_slice(_nonce);
 
         let cipher = Aes256GcmSiv::new(key);
 
-        match cipher.decrypt(nonce, _cipher_text) {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+        cipher
+            .decrypt(nonce, _cipher_text)
+            .map_err(AesGcmSivError::DecryptFailed)
     }
 }
 

--- a/src/nodex/runtime/multihash.rs
+++ b/src/nodex/runtime/multihash.rs
@@ -1,7 +1,8 @@
-use sha2::{Digest, Sha256};
-
-use crate::nodex::errors::NodeXError;
 use crate::nodex::runtime::base64_url::{Base64Url, PaddingType};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use super::jcs::JcsError;
 
 const MULTIHASH_SHA256_CODE: u8 = 0x12; // 0x12 = 18
 const MULTIHASH_SHA256_SIZE: u8 = 0x20; // 0x20 = 32
@@ -12,6 +13,18 @@ pub struct Multihash {}
 pub struct DecodedContainer {
     hash: Vec<u8>,
     algorithm: u64,
+}
+
+#[derive(Debug, Error)]
+pub enum MultihashError {
+    #[error(transparent)]
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
+    #[error(transparent)]
+    JsonCanonicalizationError(#[from] JcsError),
+    #[error("InvalidLength: {0}")]
+    InvalidLength(usize),
+    #[error("expected length is {0}, but actual length is {1}")]
+    SizeValidationFailed(usize, usize),
 }
 
 impl Multihash {
@@ -42,21 +55,12 @@ impl Multihash {
         Base64Url::encode(&hashed, &PaddingType::NoPadding)
     }
 
-    pub fn canonicalize_then_double_hash_then_encode(message: &[u8]) -> Result<String, NodeXError> {
-        let plain = match String::from_utf8(message.to_vec()) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let canonicalized = match super::jcs::Jcs::canonicalize(&plain) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn canonicalize_then_double_hash_then_encode(
+        message: &[u8],
+    ) -> Result<String, MultihashError> {
+        let plain = String::from_utf8(message.to_vec())?;
+
+        let canonicalized = super::jcs::Jcs::canonicalize(&plain)?;
 
         let hashed = Multihash::hash_as_non_multihash_buffer(canonicalized.as_bytes());
 
@@ -64,10 +68,10 @@ impl Multihash {
     }
 
     #[allow(dead_code)]
-    pub fn decode(encoded: &[u8]) -> Result<DecodedContainer, NodeXError> {
+    pub fn decode(encoded: &[u8]) -> Result<DecodedContainer, MultihashError> {
         // check for: [ code, size, digest... ]
         if encoded.len() < 2 {
-            return Err(NodeXError {});
+            return Err(MultihashError::InvalidLength(encoded.len()));
         }
 
         let code = encoded[0];
@@ -75,7 +79,10 @@ impl Multihash {
         let digest = encoded[2..].to_vec();
 
         if digest.len() != usize::from(length) {
-            return Err(NodeXError {});
+            return Err(MultihashError::SizeValidationFailed(
+                usize::from(length),
+                digest.len(),
+            ));
         }
 
         Ok(DecodedContainer {

--- a/src/nodex/runtime/random.rs
+++ b/src/nodex/runtime/random.rs
@@ -1,17 +1,12 @@
-use crate::nodex::errors::NodeXError;
-
 pub struct Random {}
 
 impl Random {
-    pub fn bytes(size: &usize) -> Result<Vec<u8>, NodeXError> {
+    pub fn bytes(size: &usize) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let mut bytes = vec![0u8; *size];
 
         match getrandom::getrandom(&mut bytes) {
             Ok(_) => Ok(bytes),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
+            Err(e) => Err(Box::new(e)),
         }
     }
 }


### PR DESCRIPTION
## Description

The error handling of nodex is too troublesome because of the error structure `NodeXError` has no information.
To simplify error handling, I've created some custom error types.

In this PR, the error type was changed by being used as a module.
I will try to change other `NodeXError` in the next PR.