### PR TITLE
chore: display log time in rfc3339

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -395,7 +395,7 @@ fn log_init() {
         writeln!(
             buf,
             "{} [{}] - {} - {} - {}:{}",
-            chrono::Local::now().format("%Y-%m-%dT%H:%M:%S"),
+            chrono::Local::now().to_rfc3339(),
             level_style.value(record.level()),
             record.target(),
             record.args(),


### PR DESCRIPTION
## Description

Currently, the agent uses a proprietary format for logging time.
However, this has no time zone, making it difficult to match the time of log to the time of the message.

To solve this, use RFC3339 format which has a timezone information.

## Check

Before
```
2024-01-30T19:07:00 [ERROR] - nodex_agent::nodex::utils::hub_client - reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("localhost")), port: Some(8000), path: "/v1/device", query: None, fragment: None }, source: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) } - src/nodex/utils/hub_client.rs:106
```

After
```
2024-01-30T19:01:52.239393+09:00 [ERROR] - nodex_agent::nodex::utils::hub_client - reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("localhost")), port: Some(8000), path: "/v1/device", query: None, fragment: None }, source: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) } - src/nodex/utils/hub_client.rs:106