### PR TITLE
refactor: NetworkConfig and AppConfig must use singleton objects.

### DIFF
--- a/src/controllers/public/nodex_receive.rs
+++ b/src/controllers/public/nodex_receive.rs
@@ -1,7 +1,6 @@
 use crate::nodex::schema::general::GeneralVcDataModel;
 use crate::services::nodex::NodeX;
 use crate::{
-    network::Network,
     nodex::errors::NodeXError,
     server,
     services::{hub::Hub, internal::didcomm_encrypted::DIDCommEncryptedService},
@@ -84,12 +83,14 @@ struct MessageReceiveUsecase {
 
 impl MessageReceiveUsecase {
     pub fn new() -> Self {
-        let network = Network::new();
-        let project_did = if let Some(v) = network.root.project_did {
+        let network = crate::network_config();
+        let network = network.lock();
+        let project_did = if let Some(v) = network.get_project_did() {
             v
         } else {
             panic!("Failed to read project_did")
         };
+        drop(network);
 
         Self {
             hub: Hub::new(),

--- a/src/handlers/heartbeat.rs
+++ b/src/handlers/heartbeat.rs
@@ -1,8 +1,6 @@
 use chrono::Utc;
 
-use crate::{
-    controllers::public::nodex_receive::ConnectionRepository, services::hub::Hub,
-};
+use crate::{controllers::public::nodex_receive::ConnectionRepository, services::hub::Hub};
 use std::sync::{atomic::AtomicBool, Arc};
 
 pub async fn handler(

--- a/src/handlers/heartbeat.rs
+++ b/src/handlers/heartbeat.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 
 use crate::{
-    controllers::public::nodex_receive::ConnectionRepository, network::Network, services::hub::Hub,
+    controllers::public::nodex_receive::ConnectionRepository, services::hub::Hub,
 };
 use std::sync::{atomic::AtomicBool, Arc};
 
@@ -9,17 +9,22 @@ pub async fn handler(
     shutdown_marker: Arc<AtomicBool>,
     connection_repository: ConnectionRepository,
 ) {
-    let network = Network::new();
+    let (heartbeat_interval_sec, project_did) = {
+        let network = crate::network_config();
+        let network = network.lock();
 
-    let heartbeat_interval_sec = match network.get_heartbeat() {
-        Some(sec) => sec,
-        None => {
-            log::info!("heartbeat is disabled");
-            return;
-        }
+        let heartbeat_interval_sec = match network.get_heartbeat() {
+            Some(sec) => sec,
+            None => {
+                log::info!("heartbeat is disabled");
+                return;
+            }
+        };
+
+        let project_did = network.get_project_did().expect("project_did is not set");
+
+        (heartbeat_interval_sec, project_did)
     };
-
-    let project_did = network.root.project_did.expect("project_did is not set");
 
     log::info!("heartbeat task is started");
     let mut interval =

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 extern crate env_logger;
 
 pub use crate::config::app_config;
-
 pub use crate::network::network_config;
 
 use crate::{config::ServerConfig, controllers::public::nodex_receive};
@@ -17,11 +16,7 @@ use services::nodex::NodeX;
 use shadow_rs::shadow;
 use std::env;
 use std::sync::atomic::AtomicBool;
-use std::{
-    collections::HashMap,
-    fs,
-    sync::{Arc},
-};
+use std::{collections::HashMap, fs, sync::Arc};
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 use tokio::time::Duration;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 extern crate env_logger;
 
-use crate::config::AppConfig;
+pub use crate::config::app_config;
+
 pub use crate::network::network_config;
 
 use crate::{config::ServerConfig, controllers::public::nodex_receive};
@@ -19,7 +20,7 @@ use std::sync::atomic::AtomicBool;
 use std::{
     collections::HashMap,
     fs,
-    sync::{Arc, Mutex, Once},
+    sync::{Arc},
 };
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
@@ -34,28 +35,6 @@ mod server;
 mod services;
 
 shadow!(build);
-
-#[derive(Clone)]
-pub struct SingletonAppConfig {
-    inner: Arc<Mutex<AppConfig>>,
-}
-
-pub fn app_config() -> Box<SingletonAppConfig> {
-    static mut SINGLETON: Option<Box<SingletonAppConfig>> = None;
-    static ONCE: Once = Once::new();
-
-    unsafe {
-        ONCE.call_once(|| {
-            let singleton = SingletonAppConfig {
-                inner: Arc::new(Mutex::new(AppConfig::new())),
-            };
-
-            SINGLETON = Some(Box::new(singleton))
-        });
-
-        SINGLETON.clone().unwrap()
-    }
-}
 
 pub fn server_config() -> ServerConfig {
     ServerConfig::new()
@@ -116,7 +95,7 @@ async fn main() -> std::io::Result<()> {
     let hub_did_topic = "nodex/did:nodex:test:EiCW6eklabBIrkTMHFpBln7574xmZlbMakWSCNtBWcunDg";
 
     let config = app_config();
-    let config = config.inner.lock().unwrap();
+    let config = config.lock();
     match config.write() {
         Ok(()) => (),
         Err(e) => {

--- a/src/nodex/extension/secure_keystore.rs
+++ b/src/nodex/extension/secure_keystore.rs
@@ -119,7 +119,7 @@ impl SecureKeyStore {
         log::info!("Called: write_internal (type: {:?})", key_type);
 
         let config = app_config();
-        let mut config = config.inner.lock().unwrap();
+        let mut config = config.lock();
 
         match key_type {
             SecureKeyStoreType::Sign => config.save_sign_key_pair(key_pair),
@@ -227,7 +227,7 @@ impl SecureKeyStore {
         log::debug!("Called: read_internal (type: {:?})", key_type);
 
         let config = app_config();
-        let config = config.inner.lock().unwrap();
+        let config = config.lock();
 
         match key_type {
             SecureKeyStoreType::Sign => config.load_sign_key_pair(),
@@ -243,7 +243,7 @@ impl SecureKeyStore {
         key_pair: &KeyPair,
     ) -> Result<(), SecureKeyStoreError> {
         let config = app_config();
-        let config = config.inner.lock().unwrap();
+        let config = config.lock();
         let extension = config.load_secure_keystore_write_sig();
 
         match extension {
@@ -257,7 +257,7 @@ impl SecureKeyStore {
         key_type: &SecureKeyStoreType,
     ) -> Result<Option<KeyPair>, SecureKeyStoreError> {
         let config = app_config();
-        let config = config.inner.lock().unwrap();
+        let config = config.lock();
         let extension = config.load_secure_keystore_read_sig();
 
         match extension {

--- a/src/nodex/extension/trng.rs
+++ b/src/nodex/extension/trng.rs
@@ -61,7 +61,7 @@ impl Trng {
 
     pub fn read(&self, size: &usize) -> Result<Vec<u8>, TrngError> {
         let config = app_config();
-        let config = config.inner.lock().unwrap();
+        let config = config.lock();
 
         if let Some(ref extension) = config.load_trng_read_sig() {
             self.read_external(extension, size)

--- a/src/nodex/keyring/keypair.rs
+++ b/src/nodex/keyring/keypair.rs
@@ -1,13 +1,12 @@
 use super::secp256k1::{Secp256k1, Secp256k1Context, Secp256k1Error};
 use crate::{
     app_config,
-    config::KeyPair,
+    config::{KeyPair, SingletonAppConfig},
     nodex::{
         extension::secure_keystore::{SecureKeyStore, SecureKeyStoreType},
         extension::{secure_keystore::SecureKeyStoreError, trng::Trng},
         runtime,
     },
-    SingletonAppConfig,
 };
 
 use thiserror::Error;
@@ -171,16 +170,14 @@ impl KeyPairing {
             _ => panic!(),
         };
 
-        let mut config = self.config.inner.lock().unwrap();
+        let mut config = self.config.lock();
         config.save_did(did);
         config.save_is_initialized(true);
     }
 
     pub fn get_identifier(&self) -> Result<String, KeyPairingError> {
         self.config
-            .inner
             .lock()
-            .unwrap()
             .get_did()
             .ok_or(KeyPairingError::DIDNotFound)
     }

--- a/src/nodex/utils/hub_client.rs
+++ b/src/nodex/utils/hub_client.rs
@@ -42,7 +42,7 @@ impl HubClient {
 
     fn auth_headers(&self, payload: String) -> Result<HeaderMap, NodeXError> {
         let config = network_config();
-        let secret = config.inner.lock().unwrap().get_secretk_key().unwrap();
+        let secret = config.lock().get_secret_key().unwrap();
         let mut mac = match HmacSha256::new_from_slice(secret.as_bytes()) {
             Ok(v) => v,
             Err(_) => {


### PR DESCRIPTION
## Description

We provides the type `SingletonNetworkConfig` and `SingletonAppConfig`. However, the use of singleton object was not corrected.

To prevent initialization and ensure that only singleton objects can be used, I've moved some structs to packages and some public methods changed to private methods.
