### PR TITLE
fix: change PAT for get-user-teams-memberships action

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           actor: ${{ github.actor }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT }}
 
   bump-version:
     name: Bump Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           actor: ${{ github.actor }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT }}
 
   build:
     name: Build


### PR DESCRIPTION
## Description

We use the action [`get-user-teams-membership`](https://github.com/tspascoal/get-user-teams-membership) to check permission.
That action needs the permission to read GitHub teams. But, the default token of GitHub actions has no permission to read it. 

I've replaced the token to solve it.

## Check

To check whether the new token has a permission, I tried to run the job `Bump Version` on this branch.

https://github.com/nodecross/nodex/actions/runs/7766165527/job/21181693650

That job failed because it was run on a branch that was not the main branch, but passed the team affiliation check.
