### PR TITLE
refactor: add custom error types for cipher/runtime/sidetree modules and simplify config loaders

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -157,31 +157,25 @@ pub enum AppConfigError {
 
 impl AppConfig {
     fn touch(path: &Path) -> io::Result<()> {
-        match OpenOptions::new().create(true).write(true).open(path) {
-            Ok(mut file) => match file.write_all(b"{}") {
-                Ok(_) => Ok(()),
-                Err(err) => Err(err),
-            },
-            Err(err) => Err(err),
-        }
+        let mut file = OpenOptions::new().create(true).write(true).open(path)?;
+        file.write_all(b"{}")?;
+        Ok(())
     }
 
+    const APP_NAME: &'static str = "nodex";
+    const CONFIG_FILE: &'static str = "config.json";
+
     fn new() -> Self {
-        let config = HomeConfig::with_config_dir("nodex", "config.json");
-        let config_dir = config.path().parent();
+        let config = HomeConfig::with_config_dir(AppConfig::APP_NAME, AppConfig::CONFIG_FILE);
+        let config_dir = config.path().parent().expect("unreachable");
 
         if !Path::exists(config.path()) {
-            match config_dir {
-                Some(v) => {
-                    match fs::create_dir_all(v) {
-                        Ok(_) => {}
-                        Err(e) => {
-                            log::error!("{:?}", e);
-                            panic!()
-                        }
-                    };
+            match fs::create_dir_all(config_dir) {
+                Ok(_) => {}
+                Err(e) => {
+                    log::error!("{:?}", e);
+                    panic!()
                 }
-                None => panic!(),
             };
 
             match Self::touch(config.path()) {

--- a/src/network.rs
+++ b/src/network.rs
@@ -9,8 +9,6 @@ use std::{fs, sync::MutexGuard};
 
 use std::sync::{Arc, Mutex, Once};
 
-use crate::nodex::errors::NodeXError;
-
 #[derive(Clone)]
 pub struct SingletonNetworkConfig {
     inner: Arc<Mutex<Network>>,
@@ -99,9 +97,9 @@ impl Network {
         Network { config, root }
     }
 
-    pub fn write(&self) -> Result<(), NodeXError> {
+    pub fn write(&self) {
         match self.config.save_json(&self.root) {
-            Ok(v) => Ok(v),
+            Ok(_v) => (),
             Err(e) => {
                 log::error!("{:?}", e);
                 panic!()
@@ -116,14 +114,7 @@ impl Network {
 
     pub fn save_secretk_key(&mut self, value: &str) {
         self.root.secret_key = Some(value.to_string());
-
-        match self.write() {
-            Ok(_) => {}
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+        self.write();
     }
 
     // NOTE: project_did
@@ -133,81 +124,37 @@ impl Network {
 
     pub fn save_project_did(&mut self, value: &str) {
         self.root.project_did = Some(value.to_string());
-
-        match self.write() {
-            Ok(_) => {}
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+        self.write();
     }
 
     // NOTE: recipient_dids
-    #[allow(dead_code)]
     pub fn get_recipient_dids(&self) -> Option<Vec<String>> {
         self.root.recipient_dids.clone()
     }
 
-    #[allow(dead_code)]
     pub fn save_recipient_dids(&mut self, value: Vec<String>) {
         self.root.recipient_dids = Some(value);
 
-        match self.write() {
-            Ok(_) => {}
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+        self.write();
     }
 
     // NOTE: hub_endpoint
-    #[allow(dead_code)]
     pub fn get_hub_endpoint(&self) -> Option<String> {
         self.root.hub_endpoint.clone()
     }
 
-    #[allow(dead_code)]
     pub fn save_hub_endpoint(&mut self, value: &str) {
         self.root.hub_endpoint = Some(value.to_string());
-
-        match self.write() {
-            Ok(_) => {}
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+        self.write();
     }
 
     // NOTE: heartbeat
-    #[allow(dead_code)]
     pub fn get_heartbeat(&self) -> Option<u64> {
         self.root.heartbeat
     }
 
-    #[allow(dead_code)]
     pub fn save_heartbeat(&mut self, value: u64) {
         self.root.heartbeat = Some(value);
-
-        match self.write() {
-            Ok(_) => {}
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
-    }
-
-    // NOTE: write
-    pub fn save(&mut self) -> Result<(), NodeXError> {
-        match self.write() {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        }
+        self.write();
     }
 }

--- a/src/nodex/cipher/credential_signer.rs
+++ b/src/nodex/cipher/credential_signer.rs
@@ -1,9 +1,10 @@
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use thiserror::Error;
 
 use crate::nodex::{
-    errors::NodeXError, keyring::secp256k1::Secp256k1, schema::general::GeneralVcDataModel, utils,
+    keyring::secp256k1::Secp256k1, schema::general::GeneralVcDataModel, utils,
 };
 
 use super::jws::Jws;
@@ -47,6 +48,18 @@ pub struct CredentialSignerSuite {
     pub context: Secp256k1,
 }
 
+#[derive(Debug, Error)]
+pub enum CredentialSignerError {
+    #[error(transparent)]
+    JwsError(#[from] super::jws::JwsError),
+    #[error(transparent)]
+    JsonParseError(#[from] serde_json::Error),
+    #[error("did is none. please set did")]
+    DidIsNone,
+    #[error("key_id is none. please set key_id")]
+    KeyIdIsNone,
+}
+
 pub struct CredentialSigner {}
 
 impl CredentialSigner {
@@ -56,28 +69,22 @@ impl CredentialSigner {
     pub fn sign(
         object: &GeneralVcDataModel,
         suite: &CredentialSignerSuite,
-    ) -> Result<GeneralVcDataModel, NodeXError> {
+    ) -> Result<GeneralVcDataModel, CredentialSignerError> {
         // FIXME:
         // if (Object.keys(object).indexOf(this.PROOF_KEY) !== -1) {
         //     throw new Error()
         // }
 
         let created = Utc::now().to_rfc3339();
-        let jws = match Jws::encode(&json!(object), &suite.context) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let jws = Jws::encode(&json!(object), &suite.context)?;
 
         let did = match &suite.did {
             Some(v) => v,
-            None => return Err(NodeXError {}),
+            None => return Err(CredentialSignerError::DidIsNone),
         };
         let key_id = match &suite.key_id {
             Some(v) => v,
-            None => return Err(NodeXError {}),
+            None => return Err(CredentialSignerError::KeyIdIsNone),
         };
 
         let proof: ProofContext = ProofContext {
@@ -98,19 +105,13 @@ impl CredentialSigner {
 
         utils::json::merge(&mut signed_object, json!(proof));
 
-        match serde_json::from_value::<GeneralVcDataModel>(signed_object) {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+        Ok(serde_json::from_value::<GeneralVcDataModel>(signed_object)?)
     }
 
     pub fn verify(
         object: &GeneralVcDataModel,
         suite: &CredentialSignerSuite,
-    ) -> Result<(Value, bool), NodeXError> {
+    ) -> Result<(Value, bool), CredentialSignerError> {
         // FIXME:
         // if (Object.keys(object).indexOf(this.PROOF_KEY) === -1) {
         //     throw new Error()
@@ -118,13 +119,7 @@ impl CredentialSigner {
 
         let mut serialized = json!(&object);
 
-        let proof = match serde_json::from_value::<Proof>(serialized["proof"].take()) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let proof = serde_json::from_value::<Proof>(serialized["proof"].take())?;
 
         // FIXME:
         // if (proof === undefined) {
@@ -138,22 +133,10 @@ impl CredentialSigner {
         // }
 
         let jws = proof.jws;
-        let payload = match serde_json::from_value::<GeneralVcDataModel>(serialized) {
-            Ok(v) => json!(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let payload = serde_json::from_value::<GeneralVcDataModel>(serialized).map(|v| json!(v))?;
 
         // NOTE: verify
-        let verified = match Jws::verify(&payload, &jws, &suite.context) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let verified = Jws::verify(&payload, &jws, &suite.context)?;
 
         Ok((payload, verified))
     }

--- a/src/nodex/cipher/signer.rs
+++ b/src/nodex/cipher/signer.rs
@@ -1,37 +1,32 @@
-use crate::nodex::{errors::NodeXError, keyring::secp256k1::Secp256k1, runtime};
+use crate::nodex::{keyring::secp256k1::Secp256k1, runtime};
+use thiserror::Error;
 
 pub struct Signer {}
 
+#[derive(Debug, Error)]
+pub enum SignerError {
+    #[error(transparent)]
+    Secp256k1Error(#[from] runtime::secp256k1::Secp256k1Error),
+}
+
 impl Signer {
-    pub fn sign(message: &str, context: &Secp256k1) -> Result<Vec<u8>, NodeXError> {
-        match runtime::secp256k1::Secp256k1::ecdsa_sign(
+    pub fn sign(message: &str, context: &Secp256k1) -> Result<Vec<u8>, SignerError> {
+        Ok(runtime::secp256k1::Secp256k1::ecdsa_sign(
             message.as_bytes(),
             &context.get_secret_key(),
-        ) {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+        )?)
     }
 
     pub fn verify(
         message: &str,
         signature: &[u8],
         context: &Secp256k1,
-    ) -> Result<bool, NodeXError> {
-        match runtime::secp256k1::Secp256k1::ecdsa_verify(
+    ) -> Result<bool, SignerError> {
+        Ok(runtime::secp256k1::Secp256k1::ecdsa_verify(
             signature,
             message.as_bytes(),
             &context.get_public_key(),
-        ) {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+        )?)
     }
 }
 

--- a/src/nodex/runtime/hmac.rs
+++ b/src/nodex/runtime/hmac.rs
@@ -2,30 +2,23 @@ use hmac::{Hmac, Mac};
 use sha2::{Sha256, Sha512};
 use thiserror::Error;
 
-use crate::nodex::errors::NodeXError;
-
 type _HmacSha256 = Hmac<Sha256>;
 type _HmacSha512 = Hmac<Sha512>;
-
-// pub trait HmacExecutable {
-//     fn digest(secret: &[u8], message: &[u8]) -> Result<Vec<u8>, NodeXError>;
-//     fn verify(secret: &[u8], message: &[u8], digest: &[u8]) -> Result<bool, NodeXError>;
-// }
 
 #[allow(dead_code)]
 pub struct HmacSha256 {}
 
 #[derive(Debug, Error)]
-pub enum HmacSha256Error {
+pub enum HmacError {
     #[error("InvalidLength")]
     InvalidLength(Box<dyn std::error::Error>),
 }
 
 impl HmacSha256 {
     #[allow(dead_code)]
-    pub fn digest(secret: &[u8], message: &[u8]) -> Result<Vec<u8>, HmacSha256Error> {
+    pub fn digest(secret: &[u8], message: &[u8]) -> Result<Vec<u8>, HmacError> {
         let mut mac = _HmacSha256::new_from_slice(secret)
-            .map_err(|e| HmacSha256Error::InvalidLength(Box::new(e)))?;
+            .map_err(|e| HmacError::InvalidLength(Box::new(e)))?;
 
         mac.update(message);
 
@@ -33,7 +26,7 @@ impl HmacSha256 {
     }
 
     #[allow(dead_code)]
-    pub fn verify(secret: &[u8], message: &[u8], digest: &[u8]) -> Result<bool, HmacSha256Error> {
+    pub fn verify(secret: &[u8], message: &[u8], digest: &[u8]) -> Result<bool, HmacError> {
         let computed = HmacSha256::digest(secret, message)?;
         Ok(computed.eq(digest))
     }
@@ -44,14 +37,9 @@ pub struct HmacSha512 {}
 
 impl HmacSha512 {
     #[allow(dead_code)]
-    pub fn digest(secret: &[u8], message: &[u8]) -> Result<Vec<u8>, NodeXError> {
-        let mut mac = match _HmacSha512::new_from_slice(secret) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn digest(secret: &[u8], message: &[u8]) -> Result<Vec<u8>, HmacError> {
+        let mut mac = _HmacSha512::new_from_slice(secret)
+            .map_err(|e| HmacError::InvalidLength(Box::new(e)))?;
 
         mac.update(message);
 
@@ -59,14 +47,8 @@ impl HmacSha512 {
     }
 
     #[allow(dead_code)]
-    pub fn verify(secret: &[u8], message: &[u8], digest: &[u8]) -> Result<bool, NodeXError> {
-        let computed = match HmacSha512::digest(secret, message) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn verify(secret: &[u8], message: &[u8], digest: &[u8]) -> Result<bool, HmacError> {
+        let computed = HmacSha512::digest(secret, message)?;
 
         Ok(computed.eq(digest))
     }

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -324,13 +324,7 @@ impl Hub {
                     network.save_recipient_dids(v.recipient_dids);
                     network.save_hub_endpoint(&v.hub_endpoint);
                     network.save_heartbeat(v.heartbeat);
-                    match network.save() {
-                        Ok(_) => Ok(()),
-                        Err(e) => {
-                            log::error!("{:?}", e);
-                            Err(NodeXError {})
-                        }
-                    }
+                    Ok(())
                 }
 
                 Err(e) => {

--- a/src/services/nodex.rs
+++ b/src/services/nodex.rs
@@ -3,7 +3,7 @@ use crate::nodex::{
     errors::NodeXError,
     keyring,
     sidetree::payload::{
-        CommitmentKeys, DIDCreateRequest, DIDResolutionResponse, OperationPayload,
+        CommitmentKeys, DIDCreateRequest, DIDResolutionResponse, OperationPayloadBuilder,
     },
     utils::http_client::{HttpClient, HttpClientConfig},
 };
@@ -81,7 +81,7 @@ impl NodeX {
             }
         };
 
-        let payload = match OperationPayload::did_create_payload(&DIDCreateRequest {
+        let payload = match OperationPayloadBuilder::did_create_payload(&DIDCreateRequest {
             public_keys: vec![public],
             commitment_keys: CommitmentKeys { recovery, update },
             service_endpoints: vec![],


### PR DESCRIPTION
## Description

#222 cont.

- To debug easily, I've created custom error types
- Network.rs and Config.rs has a lot of unnecessary lines. So I removed it.

