### PR TITLE
refactor: Goodbye NodeXError. Welcome to anyhow::Error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
 name = "array-init"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2552,7 @@ dependencies = [
  "actix-web",
  "actix-web-actors",
  "aes-gcm-siv",
+ "anyhow",
  "arrayref",
  "async-trait",
  "base64 0.21.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ shadow-rs = "0.21.0"
 dotenv = "0.15.0"
 mac_address = "1.1.5"
 
+anyhow = "1.0.79"
 thiserror = "1.0.30"
 
 [dev-dependencies]

--- a/src/nodex/errors/mod.rs
+++ b/src/nodex/errors/mod.rs
@@ -1,2 +1,0 @@
-#[derive(Debug)]
-pub struct NodeXError {}

--- a/src/nodex/extension/trng.rs
+++ b/src/nodex/extension/trng.rs
@@ -1,4 +1,8 @@
-use crate::{app_config, config::Extension, nodex::runtime::random::Random};
+use crate::{
+    app_config,
+    config::Extension,
+    nodex::runtime::random::{Random, RandomError},
+};
 use std::{ffi::CStr, num::NonZeroU32};
 
 use thiserror::Error;
@@ -14,7 +18,7 @@ pub enum TrngError {
     #[error("External function failed")]
     ExternalFunctionFailed(NonZeroU32),
     #[error("Random generation failed")]
-    RandomGenerationFailed(Box<dyn std::error::Error>),
+    RandomGenerationFailed(#[from] RandomError),
 }
 
 impl Trng {

--- a/src/nodex/mod.rs
+++ b/src/nodex/mod.rs
@@ -1,6 +1,5 @@
 pub mod agent;
 pub mod cipher;
-pub mod errors;
 pub mod extension;
 pub mod keyring;
 pub mod runtime;

--- a/src/nodex/runtime/random.rs
+++ b/src/nodex/runtime/random.rs
@@ -1,13 +1,19 @@
+use thiserror::Error;
+
 pub struct Random {}
 
+#[derive(Debug, Error)]
+pub enum RandomError {
+    #[error(transparent)]
+    GetRandomError(#[from] getrandom::Error),
+}
+
 impl Random {
-    pub fn bytes(size: &usize) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    pub fn bytes(size: &usize) -> Result<Vec<u8>, RandomError> {
         let mut bytes = vec![0u8; *size];
 
-        match getrandom::getrandom(&mut bytes) {
-            Ok(_) => Ok(bytes),
-            Err(e) => Err(Box::new(e)),
-        }
+        getrandom::getrandom(&mut bytes)?;
+        Ok(bytes)
     }
 }
 

--- a/src/nodex/utils/http_client.rs
+++ b/src/nodex/utils/http_client.rs
@@ -1,4 +1,3 @@
-use crate::nodex::errors::NodeXError;
 use reqwest::{
     header::{HeaderMap, HeaderValue},
     Url,
@@ -15,14 +14,8 @@ pub struct HttpClient {
 }
 
 impl HttpClient {
-    pub fn new(_config: &HttpClientConfig) -> Result<Self, NodeXError> {
-        let url = match Url::parse(&_config.base_url.to_string()) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn new(_config: &HttpClientConfig) -> anyhow::Result<Self> {
+        let url = Url::parse(&_config.base_url.to_string())?;
         let client: reqwest::Client = reqwest::Client::new();
 
         Ok(HttpClient {
@@ -40,79 +33,59 @@ impl HttpClient {
         headers
     }
 
-    pub async fn get(&self, _path: &str) -> Result<reqwest::Response, NodeXError> {
+    pub async fn get(&self, _path: &str) -> anyhow::Result<reqwest::Response> {
         let url = self.base_url.join(_path);
 
-        match self
+        let response = self
             .instance
             .get(&url.unwrap().to_string())
             .headers(self.default_headers())
             .send()
-            .await
-        {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+            .await?;
+
+        Ok(response)
     }
 
-    pub async fn post(&self, _path: &str, body: &str) -> Result<reqwest::Response, NodeXError> {
+    pub async fn post(&self, _path: &str, body: &str) -> anyhow::Result<reqwest::Response> {
         let url = self.base_url.join(_path);
 
-        match self
+        let response = self
             .instance
             .post(&url.unwrap().to_string())
             .headers(self.default_headers())
             .body(body.to_string())
             .send()
-            .await
-        {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+            .await?;
+
+        Ok(response)
     }
 
     #[allow(dead_code)]
-    pub async fn put(&self, _path: &str) -> Result<reqwest::Response, NodeXError> {
+    pub async fn put(&self, _path: &str) -> anyhow::Result<reqwest::Response> {
         let url = self.base_url.join(_path);
 
-        match self
+        let response = self
             .instance
             .put(&url.unwrap().to_string())
             .headers(self.default_headers())
             .send()
-            .await
-        {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+            .await?;
+
+        Ok(response)
     }
 
     #[allow(dead_code)]
-    pub async fn delete(&self, _path: &str) -> Result<reqwest::Response, NodeXError> {
+    pub async fn delete(&self, _path: &str) -> anyhow::Result<reqwest::Response> {
         let url = self.base_url.join(_path);
 
-        match self
+        let response = self
             .instance
             .delete(&url.unwrap().to_string())
             .headers(self.default_headers())
             .send()
-            .await
-        {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+            .await?;
+
+        Ok(response)
     }
 }
 

--- a/src/nodex/utils/hub_client.rs
+++ b/src/nodex/utils/hub_client.rs
@@ -1,5 +1,4 @@
 use crate::network_config;
-use crate::nodex::errors::NodeXError;
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use reqwest::{
@@ -24,14 +23,8 @@ pub struct HubClient {
 }
 
 impl HubClient {
-    pub fn new(_config: &HubClientConfig) -> Result<Self, NodeXError> {
-        let url = match Url::parse(&_config.base_url.to_string()) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn new(_config: &HubClientConfig) -> anyhow::Result<Self> {
+        let url = Url::parse(&_config.base_url.to_string())?;
         let client: reqwest::Client = reqwest::Client::new();
 
         Ok(HubClient {
@@ -40,15 +33,11 @@ impl HubClient {
         })
     }
 
-    fn auth_headers(&self, payload: String) -> Result<HeaderMap, NodeXError> {
+    fn auth_headers(&self, payload: String) -> anyhow::Result<HeaderMap> {
         let config = network_config();
         let secret = config.lock().get_secret_key().unwrap();
-        let mut mac = match HmacSha256::new_from_slice(secret.as_bytes()) {
-            Ok(v) => v,
-            Err(_) => {
-                return Err(NodeXError {});
-            }
-        };
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes())?;
+
         mac.update(payload.as_bytes());
         let signature = &hex::encode(mac.finalize().into_bytes());
         let mut headers = HeaderMap::new();
@@ -64,49 +53,27 @@ impl HubClient {
     }
 
     #[allow(dead_code)]
-    pub async fn get(&self, _path: &str) -> Result<reqwest::Response, NodeXError> {
-        let url = self.base_url.join(_path);
-        let headers = self.auth_headers("".to_string());
-        if let Err(e) = headers {
-            log::error!("{:?}", e);
-            return Err(NodeXError {});
-        }
-        match self
-            .instance
-            .get(&url.unwrap().to_string())
-            .headers(headers.unwrap())
-            .send()
-            .await
-        {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+    pub async fn get(&self, _path: &str) -> anyhow::Result<reqwest::Response> {
+        let url = self.base_url.join(_path)?;
+        let headers = self.auth_headers("".to_string())?;
+
+        let response = self.instance.get(url).headers(headers).send().await?;
+        Ok(response)
     }
 
-    pub async fn post(&self, path: &str, body: &str) -> Result<reqwest::Response, NodeXError> {
-        let url = self.base_url.join(path);
-        let headers = self.auth_headers(body.to_string());
-        if let Err(e) = headers {
-            log::error!("{:?}", e);
-            return Err(NodeXError {});
-        }
-        match self
+    pub async fn post(&self, path: &str, body: &str) -> anyhow::Result<reqwest::Response> {
+        let url = self.base_url.join(path)?;
+        let headers = self.auth_headers(body.to_string())?;
+
+        let response = self
             .instance
-            .post(&url.unwrap().to_string())
-            .headers(headers.unwrap())
+            .post(url)
+            .headers(headers)
             .body(body.to_string())
             .send()
-            .await
-        {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+            .await?;
+
+        Ok(response)
     }
 
     pub async fn send_device_info(
@@ -116,42 +83,29 @@ impl HubClient {
         mac_address: &str,
         version: &str,
         os: &str,
-    ) -> Result<reqwest::Response, NodeXError> {
+    ) -> anyhow::Result<reqwest::Response> {
         let message = json!({
             "mac_address": mac_address,
             "version": version,
             "os": os,
         });
-        let payload =
-            match DIDCommEncryptedService::generate(project_did, &json!(message), None).await {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
-        let payload = match serde_json::to_string(&payload) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let url = self.base_url.join(path);
-        self.post(url.unwrap().as_ref(), &payload).await
+        let payload = DIDCommEncryptedService::generate(project_did, &json!(message), None).await?;
+        let payload = serde_json::to_string(&payload)?;
+        let url = self.base_url.join(path)?;
+        self.post(url.as_ref(), &payload).await
     }
 
     pub async fn get_message(
         &self,
         path: &str,
         project_did: &str,
-    ) -> Result<reqwest::Response, NodeXError> {
+    ) -> anyhow::Result<reqwest::Response> {
         let payload =
             DIDCommEncryptedService::generate(project_did, &serde_json::Value::Null, None)
                 .await?
                 .to_string();
-        let url = self.base_url.join(path);
-        self.post(url.unwrap().as_ref(), &payload).await
+        let url = self.base_url.join(path)?;
+        self.post(url.as_ref(), &payload).await
     }
 
     pub async fn ack_message(
@@ -160,7 +114,7 @@ impl HubClient {
         project_did: &str,
         message_id: String,
         is_verified: bool,
-    ) -> Result<reqwest::Response, NodeXError> {
+    ) -> anyhow::Result<reqwest::Response> {
         let url = self.base_url.join(path);
         let payload = json!({
             "message_id": message_id,
@@ -177,7 +131,7 @@ impl HubClient {
         path: &str,
         to_did: &str,
         message: serde_json::Value,
-    ) -> Result<reqwest::Response, NodeXError> {
+    ) -> anyhow::Result<reqwest::Response> {
         let payload = DIDCommEncryptedService::generate(to_did, &message, None)
             .await?
             .to_string();
@@ -191,7 +145,7 @@ impl HubClient {
         project_did: &str,
         is_active: bool,
         event_at: DateTime<Utc>,
-    ) -> Result<reqwest::Response, NodeXError> {
+    ) -> anyhow::Result<reqwest::Response> {
         let url = self.base_url.join(path);
         let payload = json!({
             "event_at": event_at.to_rfc3339(),
@@ -208,71 +162,29 @@ impl HubClient {
         &self,
         path: &str,
         project_did: &str,
-    ) -> Result<reqwest::Response, NodeXError> {
+    ) -> anyhow::Result<reqwest::Response> {
         let payload =
-            match DIDCommEncryptedService::generate(project_did, &serde_json::Value::Null, None)
-                .await
-            {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
-        let payload = match serde_json::to_string(&payload) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+            DIDCommEncryptedService::generate(project_did, &serde_json::Value::Null, None).await?;
+        let payload = serde_json::to_string(&payload)?;
         self.post(path, &payload).await
     }
 
     #[allow(dead_code)]
-    pub async fn put(&self, _path: &str) -> Result<reqwest::Response, NodeXError> {
-        let url = self.base_url.join(_path);
-        let headers = self.auth_headers("".to_string());
-        if let Err(e) = headers {
-            log::error!("{:?}", e);
-            return Err(NodeXError {});
-        }
-        match self
-            .instance
-            .put(&url.unwrap().to_string())
-            .headers(headers.unwrap())
-            .send()
-            .await
-        {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+    pub async fn put(&self, _path: &str) -> anyhow::Result<reqwest::Response> {
+        let url = self.base_url.join(_path)?;
+        let headers = self.auth_headers("".to_string())?;
+        let response = self.instance.put(url).headers(headers).send().await?;
+
+        Ok(response)
     }
 
     #[allow(dead_code)]
-    pub async fn delete(&self, _path: &str) -> Result<reqwest::Response, NodeXError> {
-        let url = self.base_url.join(_path);
-        let headers = self.auth_headers("".to_string());
-        if let Err(e) = headers {
-            log::error!("{:?}", e);
-            return Err(NodeXError {});
-        }
-        match self
-            .instance
-            .delete(&url.unwrap().to_string())
-            .headers(headers.unwrap())
-            .send()
-            .await
-        {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+    pub async fn delete(&self, _path: &str) -> anyhow::Result<reqwest::Response> {
+        let url = self.base_url.join(_path)?;
+        let headers = self.auth_headers("".to_string())?;
+        let response = self.instance.delete(url).headers(headers).send().await?;
+
+        Ok(response)
     }
 }
 

--- a/src/services/internal/did_vc.rs
+++ b/src/services/internal/did_vc.rs
@@ -1,6 +1,5 @@
 use crate::nodex::{
     cipher::credential_signer::{CredentialSigner, CredentialSignerSuite},
-    errors::NodeXError,
     keyring::{self},
     schema::general::{CredentialSubject, GeneralVcDataModel, Issuer},
 };
@@ -10,21 +9,9 @@ use serde_json::{json, Value};
 pub struct DIDVCService {}
 
 impl DIDVCService {
-    pub fn generate(message: &Value) -> Result<Value, NodeXError> {
-        let keyring = match keyring::keypair::KeyPairing::load_keyring() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let did = match keyring.get_identifier() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn generate(message: &Value) -> anyhow::Result<Value> {
+        let keyring = keyring::keypair::KeyPairing::load_keyring()?;
+        let did = keyring.get_identifier()?;
 
         let r#type = "VerifiableCredential".to_string();
         let context = "https://www.w3.org/2018/credentials/v1".to_string();
@@ -44,80 +31,46 @@ impl DIDVCService {
             proof: None,
         };
 
-        let signed = match CredentialSigner::sign(
+        let signed = CredentialSigner::sign(
             &model,
             &CredentialSignerSuite {
                 did: Some(did),
                 key_id: Some("signingKey".to_string()),
                 context: keyring.get_sign_key_pair(),
             },
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                panic!()
-            }
-        };
+        )?;
 
         Ok(json!(signed))
     }
 
-    pub async fn verify(message: &Value) -> Result<Value, NodeXError> {
+    pub async fn verify(message: &Value) -> anyhow::Result<Value> {
         let service = crate::services::nodex::NodeX::new();
 
-        let model = match serde_json::from_value::<GeneralVcDataModel>(message.clone()) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let model = serde_json::from_value::<GeneralVcDataModel>(message.clone())?;
 
-        let did_document = match service.find_identifier(&model.issuer.id).await {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let public_keys = match did_document.did_document.public_key {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
+        let did_document = service.find_identifier(&model.issuer.id).await?;
+        let public_keys = did_document
+            .did_document
+            .public_key
+            .ok_or(anyhow::anyhow!("public_key is not found in did_document"))?;
 
         // FIXME: workaround
-        if public_keys.len() != 1 {
-            return Err(NodeXError {});
-        }
+        anyhow::ensure!(public_keys.len() == 1, "public_keys length must be 1");
 
         let public_key = public_keys[0].clone();
 
-        let context = match keyring::secp256k1::Secp256k1::from_jwk(&public_key.public_key_jwk) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let context = keyring::secp256k1::Secp256k1::from_jwk(&public_key.public_key_jwk)?;
 
-        let (verified_model, verified) = match CredentialSigner::verify(
+        let (verified_model, verified) = CredentialSigner::verify(
             &model,
             &CredentialSignerSuite {
                 did: None,
                 key_id: None,
                 context,
             },
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        )?;
 
-        if !verified {
-            return Err(NodeXError {});
-        }
+        anyhow::ensure!(verified, "signature is not verified");
 
         Ok(verified_model)
     }

--- a/src/services/internal/did_vp.rs
+++ b/src/services/internal/did_vp.rs
@@ -1,13 +1,11 @@
-use crate::nodex::errors::NodeXError;
-
 pub struct DIDVPService {}
 
 impl DIDVPService {
-    pub fn generate() -> Result<String, NodeXError> {
+    pub fn generate() -> anyhow::Result<String> {
         Ok("NotImplemented".to_string())
     }
 
-    pub fn verify() -> Result<String, NodeXError> {
+    pub fn verify() -> anyhow::Result<String> {
         Ok("NotImplemented".to_string())
     }
 }

--- a/src/services/internal/didcomm_encrypted.rs
+++ b/src/services/internal/didcomm_encrypted.rs
@@ -1,7 +1,6 @@
 use super::{attachment_link, did_vc::DIDVCService, types::VerifiedContainer};
 use crate::nodex::{
-    errors::NodeXError,
-    keyring::{self},
+    keyring,
     runtime::{
         self,
         base64_url::{self, PaddingType},
@@ -24,88 +23,44 @@ impl DIDCommEncryptedService {
         to_did: &str,
         message: &Value,
         metadata: Option<&Value>,
-    ) -> Result<Value, NodeXError> {
+    ) -> anyhow::Result<Value> {
         let service = crate::services::nodex::NodeX::new();
 
         // NOTE: recipient from
-        let my_keyring = match keyring::keypair::KeyPairing::load_keyring() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let my_did = match my_keyring.get_identifier() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let my_keyring = keyring::keypair::KeyPairing::load_keyring()?;
+        let my_did = my_keyring.get_identifier()?;
 
         // NOTE: recipient to
-        let did_document = match service.find_identifier(to_did).await {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let public_keys = match did_document.did_document.public_key {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
+        let did_document = service.find_identifier(to_did).await?;
+        let public_keys = did_document
+            .did_document
+            .public_key
+            .ok_or(anyhow::anyhow!("DidPublicKey not found"))?;
 
         // FIXME: workaround
-        if public_keys.len() != 1 {
-            return Err(NodeXError {});
-        }
+        anyhow::ensure!(public_keys.len() == 1, "public_keys length must be 1");
 
         let public_key = public_keys[0].clone();
 
-        let other_key = match keyring::secp256k1::Secp256k1::from_jwk(&public_key.public_key_jwk) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let other_key = keyring::secp256k1::Secp256k1::from_jwk(&public_key.public_key_jwk)?;
 
         // NOTE: ecdh
-        let shared_key = match runtime::secp256k1::Secp256k1::ecdh(
+        let shared_key = runtime::secp256k1::Secp256k1::ecdh(
             &my_keyring.get_sign_key_pair().get_secret_key(),
             &other_key.get_public_key(),
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        )?;
 
         let sk = StaticSecret::from(array_ref!(shared_key, 0, 32).to_owned());
         let pk = PublicKey::from(&sk);
 
         // NOTE: message
-        let body = match DIDVCService::generate(message) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let body = DIDVCService::generate(message)?;
 
-        let mut message = match Message::new()
+        let mut message = Message::new()
             .from(&my_did)
             .to(&[to_did])
             .body(&body.to_string())
-        {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("Failed to initialize message with error = {:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+            .map_err(|e| anyhow::anyhow!("Failed to initialize message with error = {:?}", e))?;
 
         // NOTE: Has attachment
         if let Some(value) = metadata {
@@ -124,7 +79,7 @@ impl DIDCommEncryptedService {
             )
         }
 
-        match message
+        let seal_signed_message = message
             .clone()
             .as_jwe(&CryptoAlgorithm::XC20P, Some(pk.as_bytes().to_vec()))
             .seal_signed(
@@ -132,120 +87,64 @@ impl DIDCommEncryptedService {
                 Some(vec![Some(pk.as_bytes().to_vec())]),
                 SignatureAlgorithm::Es256k,
                 &my_keyring.get_sign_key_pair().get_secret_key(),
-            ) {
-            Ok(v) => match serde_json::from_str::<Value>(&v) {
-                Ok(v) => Ok(v),
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    Err(NodeXError {})
-                }
-            },
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+            )
+            .map_err(|e| anyhow::anyhow!("failed to encrypt message : {:?}", e))?;
+
+        Ok(serde_json::from_str::<Value>(&seal_signed_message)?)
     }
 
-    pub async fn verify(message: &Value) -> Result<VerifiedContainer, NodeXError> {
+    pub async fn verify(message: &Value) -> anyhow::Result<VerifiedContainer> {
         let service = crate::services::nodex::NodeX::new();
 
         // NOTE: recipient to
-        let my_keyring = match keyring::keypair::KeyPairing::load_keyring() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let my_keyring = keyring::keypair::KeyPairing::load_keyring()?;
 
         // NOTE: recipient from
-        let protected = match message.get("protected") {
-            Some(v) => match v.as_str() {
-                Some(v) => v.to_string(),
-                None => return Err(NodeXError {}),
-            },
-            None => return Err(NodeXError {}),
-        };
+        let protected = message
+            .get("protected")
+            .ok_or(anyhow::anyhow!("protected not found"))?
+            .as_str()
+            .ok_or(anyhow::anyhow!("failed to serialize protected"))?;
 
-        let decoded =
-            match base64_url::Base64Url::decode_as_string(&protected, &PaddingType::NoPadding) {
-                Ok(v) => match serde_json::from_str::<Value>(&v) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        log::error!("{:?}", e);
-                        return Err(NodeXError {});
-                    }
-                },
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+        let decoded = base64_url::Base64Url::decode_as_string(protected, &PaddingType::NoPadding)?;
+        let decoded = serde_json::from_str::<Value>(&decoded)?;
 
-        let other_did = match decoded.get("skid") {
-            Some(v) => match v.as_str() {
-                Some(v) => v.to_string(),
-                None => return Err(NodeXError {}),
-            },
-            None => return Err(NodeXError {}),
-        };
+        let other_did = decoded
+            .get("skid")
+            .ok_or(anyhow::anyhow!("skid not found"))?
+            .as_str()
+            .ok_or(anyhow::anyhow!("failed to serialize skid"))?;
 
-        let did_document = match service.find_identifier(&other_did).await {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let did_document = service.find_identifier(other_did).await?;
 
-        let public_keys = match did_document.did_document.public_key {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
+        let public_keys = did_document
+            .did_document
+            .public_key
+            .ok_or(anyhow::anyhow!("public_key is not found in did_document"))?;
 
         // FIXME: workaround
-        if public_keys.len() != 1 {
-            return Err(NodeXError {});
-        }
+        anyhow::ensure!(public_keys.len() == 1, "public_keys length must be 1");
 
         let public_key = public_keys[0].clone();
 
-        let other_key = match keyring::secp256k1::Secp256k1::from_jwk(&public_key.public_key_jwk) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let other_key = keyring::secp256k1::Secp256k1::from_jwk(&public_key.public_key_jwk)?;
 
         // NOTE: ecdh
-        let shared_key = match runtime::secp256k1::Secp256k1::ecdh(
+        let shared_key = runtime::secp256k1::Secp256k1::ecdh(
             &my_keyring.get_sign_key_pair().get_secret_key(),
             &other_key.get_public_key(),
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        )?;
 
         let sk = StaticSecret::from(array_ref!(shared_key, 0, 32).to_owned());
         let pk = PublicKey::from(&sk);
 
-        let message = match Message::receive(
+        let message = Message::receive(
             &message.to_string(),
             Some(sk.to_bytes().as_ref()),
             Some(pk.as_bytes().to_vec()),
             Some(&other_key.get_public_key()),
-        ) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        )
+        .map_err(|e| anyhow::anyhow!("failed to decrypt message : {:?}", e))?;
 
         let metadata = message
             .attachment_iter()
@@ -254,31 +153,25 @@ impl DIDCommEncryptedService {
                 None => false,
             });
 
-        let body = match message.clone().get_body() {
-            Ok(v) => match serde_json::from_str::<GeneralVcDataModel>(&v) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            },
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let body = message
+            .clone()
+            .get_body()
+            .map_err(|e| anyhow::anyhow!("failed to get body : {:?}", e))?;
+        let body = serde_json::from_str::<GeneralVcDataModel>(&body)?;
 
         match metadata {
-            Some(metadata) => match metadata.data.json.clone() {
-                Some(json) => match serde_json::from_str::<Value>(&json) {
-                    Ok(metadata) => Ok(VerifiedContainer {
-                        message: body,
-                        metadata: Some(metadata),
-                    }),
-                    _ => Err(NodeXError {}),
-                },
-                _ => Err(NodeXError {}),
-            },
+            Some(metadata) => {
+                let metadata = metadata
+                    .data
+                    .json
+                    .as_ref()
+                    .ok_or(anyhow::anyhow!("metadata not found"))?;
+                let metadata = serde_json::from_str::<Value>(metadata)?;
+                Ok(VerifiedContainer {
+                    message: body,
+                    metadata: Some(metadata),
+                })
+            }
             None => Ok(VerifiedContainer {
                 message: body,
                 metadata: None,

--- a/src/services/internal/didcomm_plaintext.rs
+++ b/src/services/internal/didcomm_plaintext.rs
@@ -1,6 +1,5 @@
 use super::{attachment_link, did_vc::DIDVCService, types::VerifiedContainer};
 use crate::nodex::{
-    errors::NodeXError,
     keyring::{self},
     schema::general::GeneralVcDataModel,
 };
@@ -15,41 +14,17 @@ impl DIDCommPlaintextService {
         to_did: &str,
         message: &Value,
         metadata: Option<&Value>,
-    ) -> Result<Value, NodeXError> {
-        let keyring = match keyring::keypair::KeyPairing::load_keyring() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let did = match keyring.get_identifier() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    ) -> anyhow::Result<Value> {
+        let keyring = keyring::keypair::KeyPairing::load_keyring()?;
+        let did = keyring.get_identifier()?;
 
-        let body = match DIDVCService::generate(message) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let body = DIDVCService::generate(message)?;
 
-        let mut message = match Message::new()
+        let mut message = Message::new()
             .from(&did)
             .to(&[to_did])
             .body(&body.to_string())
-        {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("Failed to initialize message with error = {:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+            .map_err(|e| anyhow::anyhow!("Failed to initialize message with error = {:?}", e))?;
 
         // NOTE: Has attachment
         if let Some(value) = metadata {
@@ -67,29 +42,16 @@ impl DIDCommPlaintextService {
             )
         }
 
-        match message.clone().as_raw_json() {
-            Ok(v) => match serde_json::from_str::<Value>(&v) {
-                Ok(v) => Ok(v),
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    Err(NodeXError {})
-                }
-            },
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+        let raw_json = message
+            .clone()
+            .as_raw_json()
+            .map_err(|e| anyhow::anyhow!("failed to serialize message. error = {:?}", e))?;
+        Ok(serde_json::from_str(&raw_json)?)
     }
 
-    pub fn verify(message: &Value) -> Result<VerifiedContainer, NodeXError> {
-        let message = match Message::receive(&message.to_string(), None, None, None) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    pub fn verify(message: &Value) -> anyhow::Result<VerifiedContainer> {
+        let message = Message::receive(&message.to_string(), None, None, None)
+            .map_err(|e| anyhow::anyhow!("message construct failed. error = {:?}", e))?;
 
         let metadata = message
             .attachment_iter()
@@ -98,31 +60,25 @@ impl DIDCommPlaintextService {
                 None => false,
             });
 
-        let body = match message.clone().get_body() {
-            Ok(v) => match serde_json::from_str::<GeneralVcDataModel>(&v) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            },
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let body = message
+            .clone()
+            .get_body()
+            .map_err(|e| anyhow::anyhow!("failed to get body. error = {:?}", e))?;
+        let body = serde_json::from_str::<GeneralVcDataModel>(&body)?;
 
         match metadata {
-            Some(metadata) => match metadata.data.json.clone() {
-                Some(json) => match serde_json::from_str::<Value>(&json) {
-                    Ok(metadata) => Ok(VerifiedContainer {
-                        message: body,
-                        metadata: Some(metadata),
-                    }),
-                    _ => Err(NodeXError {}),
-                },
-                _ => Err(NodeXError {}),
-            },
+            Some(metadata) => {
+                let metadata = metadata
+                    .data
+                    .json
+                    .clone()
+                    .ok_or(anyhow::anyhow!("metadata not found"))?;
+                let metadata = serde_json::from_str::<Value>(&metadata)?;
+                Ok(VerifiedContainer {
+                    message: body,
+                    metadata: Some(metadata),
+                })
+            }
             None => Ok(VerifiedContainer {
                 message: body,
                 metadata: None,

--- a/src/services/internal/didcomm_signed.rs
+++ b/src/services/internal/didcomm_signed.rs
@@ -1,5 +1,4 @@
 use crate::nodex::{
-    errors::NodeXError,
     keyring::{self},
     runtime::base64_url::{self, PaddingType},
     schema::general::GeneralVcDataModel,
@@ -20,41 +19,17 @@ impl DIDCommSignedService {
         to_did: &str,
         message: &Value,
         metadata: Option<&Value>,
-    ) -> Result<Value, NodeXError> {
-        let keyring = match keyring::keypair::KeyPairing::load_keyring() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let did = match keyring.get_identifier() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+    ) -> anyhow::Result<Value> {
+        let keyring = keyring::keypair::KeyPairing::load_keyring()?;
+        let did = keyring.get_identifier()?;
 
-        let body = match DIDVCService::generate(message) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let body = DIDVCService::generate(message)?;
 
-        let mut message = match Message::new()
+        let mut message = Message::new()
             .from(&did)
             .to(&[to_did])
             .body(&body.to_string())
-        {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("Failed to initialize message with error = {:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+            .map_err(|e| anyhow::anyhow!("Failed to initialize message with error = {:?}", e))?;
 
         // NOTE: Has attachment
         if let Some(value) = metadata {
@@ -72,93 +47,52 @@ impl DIDCommSignedService {
             )
         }
 
-        match message.clone().as_jws(&SignatureAlgorithm::Es256k).sign(
-            SignatureAlgorithm::Es256k.signer(),
-            &keyring.get_sign_key_pair().get_secret_key(),
-        ) {
-            Ok(v) => match serde_json::from_str::<Value>(&v) {
-                Ok(v) => Ok(v),
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    Err(NodeXError {})
-                }
-            },
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+        let jws = message
+            .clone()
+            .as_jws(&SignatureAlgorithm::Es256k)
+            .sign(
+                SignatureAlgorithm::Es256k.signer(),
+                &keyring.get_sign_key_pair().get_secret_key(),
+            )
+            .map_err(|e| anyhow::anyhow!("failed to convert to jws. error = {:?}", e))?;
+
+        Ok(serde_json::from_str::<Value>(&jws)?)
     }
 
-    pub async fn verify(message: &Value) -> Result<VerifiedContainer, NodeXError> {
+    pub async fn verify(message: &Value) -> anyhow::Result<VerifiedContainer> {
         let service = crate::services::nodex::NodeX::new();
 
-        let payload = match message.get("payload") {
-            Some(v) => match v.as_str() {
-                Some(v) => v.to_string(),
-                None => return Err(NodeXError {}),
-            },
-            None => return Err(NodeXError {}),
-        };
+        let payload = message
+            .get("payload")
+            .ok_or(anyhow::anyhow!("No payload"))?
+            .as_str()
+            .ok_or(anyhow::anyhow!("failed to convert to str"))?;
 
-        let decoded =
-            match base64_url::Base64Url::decode_as_string(&payload, &PaddingType::NoPadding) {
-                Ok(v) => match serde_json::from_str::<Value>(&v) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        log::error!("{:?}", e);
-                        return Err(NodeXError {});
-                    }
-                },
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+        let decoded = base64_url::Base64Url::decode_as_string(payload, &PaddingType::NoPadding)?;
+        let decoded = serde_json::from_str::<Value>(&decoded)?;
 
-        let from_did = match decoded.get("from") {
-            Some(v) => match v.as_str() {
-                Some(v) => v.to_string(),
-                None => return Err(NodeXError {}),
-            },
-            None => return Err(NodeXError {}),
-        };
+        let from_did = decoded
+            .get("from")
+            .ok_or(anyhow::anyhow!("No from"))?
+            .as_str()
+            .ok_or(anyhow::anyhow!("failed to convert to str"))?;
 
-        let did_document = match service.find_identifier(&from_did).await {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let public_keys = match did_document.did_document.public_key {
-            Some(v) => v,
-            None => return Err(NodeXError {}),
-        };
+        let did_document = service.find_identifier(from_did).await?;
+
+        let public_keys = did_document
+            .did_document
+            .public_key
+            .ok_or(anyhow::anyhow!("public_key is not found in did_document"))?;
 
         // FIXME: workaround
-        if public_keys.len() != 1 {
-            return Err(NodeXError {});
-        }
+        anyhow::ensure!(public_keys.len() == 1, "public_key length must be 1");
 
         let public_key = public_keys[0].clone();
 
-        let context = match keyring::secp256k1::Secp256k1::from_jwk(&public_key.public_key_jwk) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let context = keyring::secp256k1::Secp256k1::from_jwk(&public_key.public_key_jwk)?;
 
-        let message =
-            match Message::verify(message.to_string().as_bytes(), &context.get_public_key()) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+        let message = Message::verify(message.to_string().as_bytes(), &context.get_public_key())
+            .map_err(|e| anyhow::anyhow!("failed to verify message. error = {:?}", e))?;
 
         let metadata = message
             .attachment_iter()
@@ -167,31 +101,24 @@ impl DIDCommSignedService {
                 None => false,
             });
 
-        let body = match message.clone().get_body() {
-            Ok(v) => match serde_json::from_str::<GeneralVcDataModel>(&v) {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            },
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let body = message
+            .get_body()
+            .map_err(|e| anyhow::anyhow!("failed to get body. error = {:?}", e))?;
+        let body = serde_json::from_str::<GeneralVcDataModel>(&body)?;
 
         match metadata {
-            Some(metadata) => match metadata.data.json.clone() {
-                Some(json) => match serde_json::from_str::<Value>(&json) {
-                    Ok(metadata) => Ok(VerifiedContainer {
-                        message: body,
-                        metadata: Some(metadata),
-                    }),
-                    _ => Err(NodeXError {}),
-                },
-                _ => Err(NodeXError {}),
-            },
+            Some(metadata) => {
+                let data = metadata
+                    .data
+                    .json
+                    .clone()
+                    .ok_or(anyhow::anyhow!("metadata not found"))?;
+                let metadata = serde_json::from_str::<Value>(&data)?;
+                Ok(VerifiedContainer {
+                    message: body,
+                    metadata: Some(metadata),
+                })
+            }
             None => Ok(VerifiedContainer {
                 message: body,
                 metadata: None,

--- a/src/services/nodex.rs
+++ b/src/services/nodex.rs
@@ -1,6 +1,5 @@
 use super::internal::didcomm_encrypted::DIDCommEncryptedService;
 use crate::nodex::{
-    errors::NodeXError,
     keyring,
     sidetree::payload::{
         CommitmentKeys, DIDCreateRequest, DIDResolutionResponse, OperationPayloadBuilder,
@@ -36,7 +35,7 @@ impl NodeX {
     }
 
     // NOTE: DONE
-    pub async fn create_identifier(&self) -> Result<DIDResolutionResponse, NodeXError> {
+    pub async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse> {
         // NOTE: find did
         if let Ok(v) = keyring::keypair::KeyPairing::load_keyring() {
             if let Ok(did) = v.get_identifier() {
@@ -47,67 +46,26 @@ impl NodeX {
         }
 
         // NOTE: does not exists did key ring
-        let mut keyring = match keyring::keypair::KeyPairing::create_keyring() {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let mut keyring = keyring::keypair::KeyPairing::create_keyring()?;
 
         // NOTE: create payload
-        let public = match keyring
+        let public = keyring
             .get_sign_key_pair()
-            .to_public_key("signingKey", &["auth", "general"])
-        {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let update = match keyring.get_recovery_key_pair().to_jwk(false) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-        let recovery = match keyring.get_update_key_pair().to_jwk(false) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
-
-        let payload = match OperationPayloadBuilder::did_create_payload(&DIDCreateRequest {
+            .to_public_key("signingKey", &["auth", "general"])?;
+        let update = keyring.get_recovery_key_pair().to_jwk(false)?;
+        let recovery = keyring.get_update_key_pair().to_jwk(false)?;
+        let payload = OperationPayloadBuilder::did_create_payload(&DIDCreateRequest {
             public_keys: vec![public],
             commitment_keys: CommitmentKeys { recovery, update },
             service_endpoints: vec![],
-        }) {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        })?;
 
-        let res = match self.http_client.post("/api/v1/operations", &payload).await {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let res = self
+            .http_client
+            .post("/api/v1/operations", &payload)
+            .await?;
 
-        let json = match res.json::<DIDResolutionResponse>().await {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+        let json = res.json::<DIDResolutionResponse>().await?;
 
         // NOTE: save context
         keyring.save(&json.did_document.id);
@@ -116,26 +74,13 @@ impl NodeX {
     }
 
     // NOTE: DONE
-    pub async fn find_identifier(&self, did: &str) -> Result<DIDResolutionResponse, NodeXError> {
-        let res = match self
+    pub async fn find_identifier(&self, did: &str) -> anyhow::Result<DIDResolutionResponse> {
+        let res = self
             .http_client
             .get(&(format!("/api/v1/identifiers/{}", &did)))
-            .await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                log::error!("{:?}", e);
-                return Err(NodeXError {});
-            }
-        };
+            .await?;
 
-        match res.json::<DIDResolutionResponse>().await {
-            Ok(v) => Ok(v),
-            Err(e) => {
-                log::error!("{:?}", e);
-                Err(NodeXError {})
-            }
-        }
+        Ok(res.json::<DIDResolutionResponse>().await?)
     }
 
     #[allow(dead_code)]
@@ -144,44 +89,22 @@ impl NodeX {
         to_did: &str,
         messages: &Vec<Value>,
         metadata: &Value,
-    ) -> Result<Value, NodeXError> {
+    ) -> anyhow::Result<Value> {
         // NOTE: didcomm (enc)
         let container =
-            match DIDCommEncryptedService::generate(to_did, &json!(messages), Some(metadata)).await
-            {
-                Ok(v) => v,
-                Err(e) => {
-                    log::error!("{:?}", e);
-                    return Err(NodeXError {});
-                }
-            };
+            DIDCommEncryptedService::generate(to_did, &json!(messages), Some(metadata)).await?;
 
         Ok(container)
     }
 
-    pub async fn update_version(&self, binary_url: &str, path: &str) -> Result<(), NodeXError> {
-        let response = reqwest::get(binary_url).await;
-        match response {
-            Ok(r) => {
-                let content = match r.bytes().await {
-                    Ok(c) => c,
-                    Err(_) => return Err(NodeXError {}),
-                };
-                match fs::write(path, &content) {
-                    Ok(_) => (),
-                    Err(_) => return Err(NodeXError {}),
-                };
-                match Command::new("chmod").arg("+x").arg(path).status() {
-                    Ok(_) => (),
-                    Err(_) => return Err(NodeXError {}),
-                };
-                match Command::new(path).spawn() {
-                    Ok(_) => (),
-                    Err(_) => return Err(NodeXError {}),
-                };
-                Ok(())
-            }
-            Err(_) => Err(NodeXError {}),
-        }
+    pub async fn update_version(&self, binary_url: &str, path: &str) -> anyhow::Result<()> {
+        let response = reqwest::get(binary_url).await?;
+        let content = response.bytes().await?;
+
+        fs::write(path, &content)?;
+
+        Command::new("chmod").arg("+x").arg(path).status()?;
+        Command::new(path).spawn()?;
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description

The original error type `NodeXError` has no information, so it is very difficult to debug errors.
NodeX is binary application, and it's suitable for using `anyhow::Error`.

I use custom errors with anyhow::error and thiserror as follows.

- `anyhow::Error`
  - uses in binary application.
  - uses when we don't need to use the method `downcast_ref' of `anyhow::Error`

- `thiserror::Error`
  - uses in common modules. (e.g. cipher/extension/keyring/sidetree/runtime in nodex module.)
  - uses when we want to handle differently in each error types in upper function.

You can now use anyhow::error in common modules. Because these modules are included in the nodex application package.
But I want to split packages to restrict using `anyhow::Error`.
I'll try to deal with this later.