### PR TITLE
fix: change permission for bump version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -13,6 +13,7 @@ on:
           - major
 
 permissions:
+  contents: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
## Description

I've tried to run the workflow "Bump Version", but it failed because of lack permission.
https://github.com/nodecross/nodex/actions/runs/7782139923/job/21217949516

I have modified my authorization to move workflow.