### PR TITLE
fix: rename input token for create-pull-request actions steps

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Create PR
         id: create-pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "chore: bump version to v${{ steps.set_crate_version.outputs.version }}"
           branch: "chore/bump-version-to-v${{ steps.set_crate_version.outputs.version }}"
@@ -73,4 +73,4 @@ jobs:
             This PR was created by the [release workflow](${{ github.event.repository.html_url }}/actions/workflows/release.yml).
 
             [release workflow]: ${{ github.event.repository.html_url }}/actions/workflows/release.yml
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

I've succeeded to run the job 'Bump Version' and the job create this [PR](https://github.com/nodecross/nodex/pull/232).

But somehow that PR Commit was tied to my account.
I fixed it because the way I passed the github token was not good.

<img width="911" alt="image" src="https://github.com/nodecross/nodex/assets/30817722/87028fe6-3d29-4c71-90d5-d8992fcc0295">
