### PR TITLE
fix: rename input name in upload-release-asset action

### DIFF
--- a/.github/actions/upload-release-asset/action.yml
+++ b/.github/actions/upload-release-asset/action.yml
@@ -28,7 +28,7 @@ runs:
       with:
         script: |
           const fs = require('fs').promises;
-          const asset = await fs.readFile("${{ inputs.content_path }}");
+          const asset = await fs.readFile("${{ inputs.asset_path }}");
           await github.rest.repos.uploadReleaseAsset({
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
## Description

I released nodex using the release workflow.
https://github.com/nodecross/nodex/actions/runs/7796128468

However, it failed because the input name for upload-release-asset was incorrect.
I changed the name from 'content_path' to 'asset_path' to fix this problem.