### PR TITLE
fix: deadlock in SecureKeyStore

### DIFF
--- a/src/nodex/extension/secure_keystore.rs
+++ b/src/nodex/extension/secure_keystore.rs
@@ -242,9 +242,11 @@ impl SecureKeyStore {
         key_type: &SecureKeyStoreType,
         key_pair: &KeyPair,
     ) -> Result<(), SecureKeyStoreError> {
-        let config = app_config();
-        let config = config.lock();
-        let extension = config.load_secure_keystore_write_sig();
+        let extension = {
+            let config = app_config();
+            let config = config.lock();
+            config.load_secure_keystore_write_sig()
+        };
 
         match extension {
             Some(v) => self.write_external(&v, key_type, key_pair),
@@ -256,9 +258,11 @@ impl SecureKeyStore {
         &self,
         key_type: &SecureKeyStoreType,
     ) -> Result<Option<KeyPair>, SecureKeyStoreError> {
-        let config = app_config();
-        let config = config.lock();
-        let extension = config.load_secure_keystore_read_sig();
+        let extension = {
+            let config = app_config();
+            let config = config.lock();
+            config.load_secure_keystore_read_sig()
+        };
 
         match extension {
             Some(v) => self.read_external(&v, key_type),


### PR DESCRIPTION
## Description

The deadlock was occurred in SecureKeyStore.

It's because SecureKeyStore::read/write has the lock, but SecureKeyStore::read_internal/write_internal wants to get the lock.

## Check

I ran the agent and tried to run a example 'yarn find_did'

```
2024-02-06T20:05:07.085070+09:00 [INFO] - nodex_agent - subscribed: nodex/did:nodex:test:EiCW6eklabBIrkTMHFpBln7574xmZlbMakWSCNtBWcunDg - src/main.rs:164
2024-02-06T20:05:07.085812+09:00 [INFO] - actix_server::builder - Starting 1 workers - /Users/rabe1028/.cargo/registry/src/index.crates.io-6f17d22bba15001f/actix-server-2.1.1/src/builder.rs:200
2024-02-06T20:05:07.086160+09:00 [INFO] - nodex_agent::handlers::receiver - start receiver - src/handlers/receiver.rs:17
2024-02-06T20:05:07.086201+09:00 [INFO] - nodex_agent::handlers::sender - start sender - src/handlers/sender.rs:16
2024-02-06T20:05:07.086198+09:00 [INFO] - actix_server::server - Tokio runtime found; starting in existing Tokio runtime - /Users/rabe1028/.cargo/registry/src/index.crates.io-6f17d22bba15001f/actix-server-2.1.1/src/server.rs:197
2024-02-06T20:05:07.086155+09:00 [INFO] - nodex_agent::controllers::public::nodex_receive - Polling task is started - src/controllers/public/nodex_receive.rs:255
2024-02-06T20:05:07.086278+09:00 [INFO] - nodex_agent::handlers::heartbeat - heartbeat is disabled - src/handlers/heartbeat.rs:17
2024-02-06T20:05:07.087427+09:00 [INFO] - nodex_agent::handlers::receiver - stop receiver - src/handlers/receiver.rs:46
2024-02-06T20:05:08.740226+09:00 [INFO] - actix_web::middleware::logger - - "GET /identifiers/did:nodex:test:EiD_ZSrS4E4FZruAIJnMt1KjvH1HvwCRYdnIzYpQr4vsuQ HTTP/1.1" 200 466 "-" "got (https://github.com/sindresorhus/got)" 0.120484 - /Users/rabe1028/.cargo/registry/src/index.crates.io-6f17d22bba15001f/actix-web-4.3.0/src/middleware/logger.rs:421
```