### PR TITLE
feat: Implement verify verifiable message

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -29,9 +29,39 @@ runs:
       shell: bash
       run: cargo install cargo-llvm-cov
 
+    - name: (setup) copy default config to home
+      shell: bash
+      run: mkdir -p ~/.config/nodex & cp test_resource/config/* ~/.config/nodex/
+
+    - name: (run) run mock server
+      shell: bash
+      run: docker compose -f test_resource/compose.yaml up -d
+
     - name: (run) tests
       shell: bash
       run: cargo llvm-cov --lcov --output-path coverage.lcov
+
+    - name: (build) build agent for e2e tests
+      shell: bash
+      run: cargo build
+
+    - name: (run) run agent for e2e tests
+      shell: bash
+      run: ./target/debug/nodex-agent > log.txt 2>&1 &
+      env:
+        NODEX_DID_HTTP_ENDPOINT: http://localhost:4010
+        NODEX_DID_ATTACHMENT_LINK: http://localhost:4010
+        NODEX_HUB_HTTP_ENDPOINT: http://localhost:8020
+
+    - name: (run) e2e tests
+      shell: bash
+      working-directory: e2e
+      run: cargo test
+
+    - name: (run) show log of agent
+      shell: bash
+      run: cat log.txt
+      if: ${{ always() }}
 
     - name: (run) upload to coveralls
       uses: coverallsapp/github-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "flate2",
  "futures-core",
  "h2",
- "http",
+ "http 0.2.8",
  "httparse",
  "httpdate",
  "itoa 1.0.2",
@@ -100,7 +100,7 @@ checksum = "eb60846b52c118f2f04a56cc90880a274271c489b2498623d58176f8ca21fa80"
 dependencies = [
  "bytestring",
  "firestorm",
- "http",
+ "http 0.2.8",
  "log",
  "regex",
  "serde",
@@ -130,7 +130,7 @@ dependencies = [
  "futures-util",
  "mio",
  "num_cpus",
- "socket2",
+ "socket2 0.4.4",
  "tokio",
  "tracing",
 ]
@@ -180,7 +180,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.8",
  "itoa 1.0.2",
  "language-tags",
  "log",
@@ -192,7 +192,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec 1.8.0",
- "socket2",
+ "socket2 0.4.4",
  "time 0.3.12",
  "url",
 ]
@@ -1276,11 +1276,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.0",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1296,13 +1296,14 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1310,6 +1311,21 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "e2e"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs 5.0.1",
+ "hex",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
+ "hyperlocal",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "ecdsa"
@@ -1826,7 +1842,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.8",
  "indexmap",
  "slab",
  "tokio",
@@ -2006,21 +2022,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.2",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.8",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -2045,16 +2095,34 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.8",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa 1.0.2",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.4",
  "tokio",
  "tower-service",
  "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "itoa 1.0.2",
+ "pin-project-lite",
+ "tokio",
  "want",
 ]
 
@@ -2064,11 +2132,45 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
- "http",
- "hyper",
+ "http 0.2.8",
+ "hyper 0.14.19",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.0-alpha"
+source = "git+https://github.com/softprops/hyperlocal.git?rev=34dc857#34dc8579d74f96b68ddbd55582c76019ae18cfdc"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2307,9 +2409,9 @@ checksum = "db7c463b5db4448022fb5829e269bf3a0dd0da21ac18e8e03bf2c5a6e53cc2b8"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
@@ -2511,14 +2613,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2563,7 +2665,7 @@ dependencies = [
  "data-encoding",
  "didcomm-rs",
  "digest 0.10.6",
- "dirs 5.0.0",
+ "dirs 5.0.1",
  "dotenv",
  "env_logger 0.10.0",
  "getrandom 0.2.7",
@@ -2789,6 +2891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,9 +3031,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -3281,9 +3389,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.8",
+ "http-body 0.4.5",
+ "hyper 0.14.19",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -3836,6 +3944,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4017,33 +4135,32 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.5",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4079,6 +4196,28 @@ checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -4414,7 +4553,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4447,26 +4586,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["iot", "embedded", "root-of-trust", "did"]
 categories = ["embedded", "cryptography"]
 build = "build.rs"
 
+[workspace]
+members = ["e2e"]
+
 [[bin]]
 name = "nodex-agent"
 path = "src/main.rs"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "e2e"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dev-dependencies]
+serde_json = { version = "1.0.71" }
+anyhow = "1.0"
+dirs = "5.0.1"
+hex = "0.4"
+http-body-util = { version = "0.1" }
+hyper = { version = "1.1", features = ["client", "http1"] }
+hyper-util = { version = "0.1.2", features = [
+    "client-legacy",
+    "http1",
+    "tokio",
+] }
+tokio = { version = "1.35", features = [
+    "io-std",
+    "io-util",
+    "macros",
+    "rt-multi-thread",
+] }
+hyperlocal = { git = "https://github.com/softprops/hyperlocal.git", rev = "34dc857" }

--- a/e2e/tests/test_verifiable_message.rs
+++ b/e2e/tests/test_verifiable_message.rs
@@ -1,0 +1,102 @@
+use http_body_util::BodyExt;
+use hyper::{body::Incoming, Method, Request, StatusCode};
+use hyper_util::client::legacy::Client;
+use hyperlocal::{UnixClientExt, UnixConnector, Uri as HyperLocalUri};
+use serde_json::json;
+use std::fs::read;
+use tokio::io::AsyncWriteExt as _;
+
+async fn response_to_string(mut response: hyper::Response<Incoming>) -> anyhow::Result<String> {
+    let mut body: Vec<u8> = Vec::with_capacity(2048);
+
+    while let Some(frame_result) = response.frame().await {
+        let frame = frame_result?;
+
+        if let Some(segment) = frame.data_ref() {
+            body.write_all(segment.iter().as_slice()).await?;
+        }
+    }
+
+    Ok(String::from_utf8(body)?)
+}
+
+async fn create_verifiable_message_scenario() -> anyhow::Result<String> {
+    let homedir = dirs::home_dir().unwrap();
+    let socket_path = homedir.join(".nodex/run/nodex.sock");
+    let client: Client<UnixConnector, _> = Client::unix();
+
+    let create_url = HyperLocalUri::new(&socket_path, "/create-verifiable-message");
+
+    let my_did = {
+        let config = read(homedir.join(".config/nodex/config.json"))?;
+        let config = serde_json::from_slice::<serde_json::Value>(&config)?;
+        config["did"].as_str().unwrap().to_string()
+    };
+
+    let body = json!({
+        "destination_did": my_did,
+        "message": "Hello, world!"
+    })
+    .to_string();
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(create_url)
+        .header("Content-Type", "application/json")
+        .body(body)?;
+    dbg!(&request);
+
+    let response = client.request(request).await?;
+    dbg!(&response);
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response_to_string(response).await?;
+    // parse check
+    let parsed = serde_json::from_str::<serde_json::Value>(&body)?;
+    dbg!(&parsed);
+    assert_eq!(
+        parsed["credentialSubject"]["container"]["payload"],
+        "Hello, world!"
+    );
+
+    Ok(body)
+}
+
+async fn verify_verifiable_message_scenario(input: String) -> anyhow::Result<()> {
+    let homedir = dirs::home_dir().unwrap();
+    let socket_path = homedir.join(".nodex/run/nodex.sock");
+    let client: Client<UnixConnector, _> = Client::unix();
+
+    let verify_url = HyperLocalUri::new(&socket_path, "/verify-verifiable-message");
+
+    let body = json!({
+        "message": input
+    })
+    .to_string();
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(verify_url)
+        .header("Content-Type", "application/json")
+        .body(body)?;
+
+    dbg!(&request);
+
+    let response = client.request(request).await?;
+    dbg!(&response);
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response_to_string(response).await?;
+
+    assert_eq!(body, "Hello, world!");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test() {
+    let input = create_verifiable_message_scenario().await.unwrap();
+    verify_verifiable_message_scenario(input).await.unwrap();
+}

--- a/src/controllers/public/mod.rs
+++ b/src/controllers/public/mod.rs
@@ -3,3 +3,4 @@ pub mod nodex_create_verifiable_message;
 pub mod nodex_find_identifier;
 pub mod nodex_receive;
 pub mod nodex_transfer;
+pub mod nodex_verify_verifiable_message;

--- a/src/controllers/public/nodex_create_verifiable_message.rs
+++ b/src/controllers/public/nodex_create_verifiable_message.rs
@@ -2,11 +2,14 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use crate::services::{
-    internal::did_vc::DIDVCService, nodex::NodeX,
-    project_verifier::ProjectVerifierImplOnNetworkConfig,
-};
 use crate::usecase::verifiable_message_usecase::VerifiableMessageUseCase;
+use crate::{
+    services::{
+        internal::did_vc::DIDVCService, nodex::NodeX,
+        project_verifier::ProjectVerifierImplOnNetworkConfig,
+    },
+    usecase::verifiable_message_usecase::CreateVerifiableMessageUseCaseError,
+};
 
 // NOTE: POST /create-verifiable-message
 #[derive(Deserialize, Serialize)]
@@ -32,9 +35,14 @@ pub async fn handler(
         .await
     {
         Ok(v) => Ok(HttpResponse::Ok().json(&v)),
-        Err(e) => {
-            log::error!("{:?}", e);
-            Ok(HttpResponse::InternalServerError().finish())
-        }
+        Err(e) => match e {
+            CreateVerifiableMessageUseCaseError::DestinationNotFound => {
+                Ok(HttpResponse::NotFound().finish())
+            }
+            CreateVerifiableMessageUseCaseError::Other(e) => {
+                log::error!("{:?}", e);
+                Ok(HttpResponse::InternalServerError().finish())
+            }
+        },
     }
 }

--- a/src/controllers/public/nodex_create_verifiable_message.rs
+++ b/src/controllers/public/nodex_create_verifiable_message.rs
@@ -34,7 +34,7 @@ pub async fn handler(
         .generate(json.destination_did, json.message, now)
         .await
     {
-        Ok(v) => Ok(HttpResponse::Ok().json(&v)),
+        Ok(v) => Ok(HttpResponse::Ok().body(v)),
         Err(e) => match e {
             CreateVerifiableMessageUseCaseError::DestinationNotFound => {
                 Ok(HttpResponse::NotFound().finish())

--- a/src/controllers/public/nodex_verify_verifiable_message.rs
+++ b/src/controllers/public/nodex_verify_verifiable_message.rs
@@ -27,7 +27,7 @@ pub async fn handler(
     );
 
     match usecase.verify(&json.message).await {
-        Ok(v) => Ok(HttpResponse::Ok().json(&v)),
+        Ok(v) => Ok(HttpResponse::Ok().body(v)),
         Err(e) => match e {
             VerifyVerifiableMessageUseCaseError::VerificationFailed => {
                 Ok(HttpResponse::Unauthorized().finish())

--- a/src/controllers/public/nodex_verify_verifiable_message.rs
+++ b/src/controllers/public/nodex_verify_verifiable_message.rs
@@ -1,0 +1,33 @@
+use actix_web::{web, HttpRequest, HttpResponse};
+use serde::{Deserialize, Serialize};
+
+use crate::services::{
+    internal::did_vc::DIDVCService, nodex::NodeX,
+    project_verifier::ProjectVerifierImplOnNetworkConfig,
+};
+use crate::usecase::verifiable_message_usecase::VerifiableMessageUseCase;
+
+// NOTE: POST /verify-verifiable-message
+#[derive(Deserialize, Serialize)]
+pub struct MessageContainer {
+    message: String,
+}
+
+pub async fn handler(
+    _req: HttpRequest,
+    web::Json(json): web::Json<MessageContainer>,
+) -> actix_web::Result<HttpResponse> {
+    let usecase = VerifiableMessageUseCase::new(
+        Box::new(ProjectVerifierImplOnNetworkConfig::new()),
+        Box::new(NodeX::new()),
+        DIDVCService::new(NodeX::new()),
+    );
+
+    match usecase.verify(&json.message).await {
+        Ok(v) => Ok(HttpResponse::Ok().json(&v)),
+        Err(e) => {
+            log::error!("{:#?}", e);
+            Ok(HttpResponse::InternalServerError().finish())
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,7 @@ fn use_cli(command: Option<Commands>, did: String) {
             Commands::Network { command } => match command {
                 NetworkSubCommands::Set { key, value } => match &*key {
                     SECRET_KEY => {
-                        network_config.save_secretk_key(&value);
+                        network_config.save_secret_key(&value);
                         print!("Network {} is set", SECRET_KEY);
                     }
                     PROJECT_DID => {

--- a/src/network.rs
+++ b/src/network.rs
@@ -109,7 +109,7 @@ impl Network {
         self.root.secret_key.clone()
     }
 
-    pub fn save_secretk_key(&mut self, value: &str) {
+    pub fn save_secret_key(&mut self, value: &str) {
         self.root.secret_key = Some(value.to_string());
         self.write();
     }

--- a/src/repository/did_repository.rs
+++ b/src/repository/did_repository.rs
@@ -1,14 +1,7 @@
 use crate::nodex::sidetree::payload::DIDResolutionResponse;
-// use thiserror::Error;
 
 #[async_trait::async_trait]
 pub trait DidRepository {
     async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse>;
     async fn find_identifier(&self, did: &str) -> anyhow::Result<Option<DIDResolutionResponse>>;
 }
-
-// #[derive(Debug, Error)]
-// pub enum DidRepositoryError {
-//     KeyPairingError,
-//     FindIdentifierError,
-// }

--- a/src/repository/did_repository.rs
+++ b/src/repository/did_repository.rs
@@ -1,7 +1,14 @@
 use crate::nodex::sidetree::payload::DIDResolutionResponse;
+// use thiserror::Error;
 
 #[async_trait::async_trait]
 pub trait DidRepository {
     async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse>;
-    async fn find_identifier(&self, did: &str) -> anyhow::Result<DIDResolutionResponse>;
+    async fn find_identifier(&self, did: &str) -> anyhow::Result<Option<DIDResolutionResponse>>;
 }
+
+// #[derive(Debug, Error)]
+// pub enum DidRepositoryError {
+//     KeyPairingError,
+//     FindIdentifierError,
+// }

--- a/src/server.rs
+++ b/src/server.rs
@@ -47,6 +47,10 @@ pub fn new_server(
                 "/create-verifiable-message",
                 web::post().to(controllers::public::nodex_create_verifiable_message::handler),
             )
+            .route(
+                "/verify-verifiable-message",
+                web::post().to(controllers::public::nodex_verify_verifiable_message::handler),
+            )
             // NOTE: Internal (Private) Routes
             .service(
                 web::scope("/internal")

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -225,7 +225,7 @@ impl Hub {
                 Ok(v) => {
                     let network = crate::network_config();
                     let mut network = network.lock();
-                    network.save_secretk_key(&v.secret_key);
+                    network.save_secret_key(&v.secret_key);
                     network.save_project_did(&v.project_did);
                     network.save_recipient_dids(v.recipient_dids);
                     network.save_hub_endpoint(&v.hub_endpoint);

--- a/src/services/internal/did_vc.rs
+++ b/src/services/internal/did_vc.rs
@@ -63,7 +63,8 @@ impl DIDVCService {
         let did_document = self
             .did_repository
             .find_identifier(&model.issuer.id)
-            .await?;
+            .await?
+            .context(format!("did {} not found", &model.issuer.id))?;
         let public_keys = did_document
             .did_document
             .public_key

--- a/src/services/internal/didcomm_encrypted.rs
+++ b/src/services/internal/didcomm_encrypted.rs
@@ -7,6 +7,7 @@ use crate::nodex::{
     },
     schema::general::GeneralVcDataModel,
 };
+use anyhow::Context;
 use arrayref::array_ref;
 use chrono::{DateTime, Utc};
 use cuid;
@@ -34,7 +35,10 @@ impl DIDCommEncryptedService {
         let my_did = my_keyring.get_identifier()?;
 
         // NOTE: recipient to
-        let did_document = service.find_identifier(to_did).await?;
+        let did_document = service
+            .find_identifier(to_did)
+            .await?
+            .context(format!("did {} not found", to_did))?;
         let public_keys = did_document
             .did_document
             .public_key
@@ -118,7 +122,10 @@ impl DIDCommEncryptedService {
             .as_str()
             .ok_or(anyhow::anyhow!("failed to serialize skid"))?;
 
-        let did_document = service.find_identifier(other_did).await?;
+        let did_document = service
+            .find_identifier(other_did)
+            .await?
+            .context(format!("did {} not found", other_did))?;
 
         let public_keys = did_document
             .did_document

--- a/src/services/internal/didcomm_signed.rs
+++ b/src/services/internal/didcomm_signed.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     services::nodex::NodeX,
 };
+use anyhow::Context;
 use chrono::{DateTime, Utc};
 use cuid;
 use didcomm_rs::{
@@ -82,7 +83,10 @@ impl DIDCommSignedService {
             .as_str()
             .ok_or(anyhow::anyhow!("failed to convert to str"))?;
 
-        let did_document = service.find_identifier(from_did).await?;
+        let did_document = service
+            .find_identifier(from_did)
+            .await?
+            .context(format!("did {} not found", from_did))?;
 
         let public_keys = did_document
             .did_document

--- a/test_resource/compose.yaml
+++ b/test_resource/compose.yaml
@@ -1,0 +1,19 @@
+version: '3.9'
+
+services:
+  sidetree_prism:
+    image: stoplight/prism:4
+    command: 'mock -h 0.0.0.0 /tmp/api.yaml'
+    volumes:
+      - ./did_sidetree.yaml:/tmp/api.yaml:ro
+    ports:
+      - '4010:4010'
+
+  studio_prism:
+    image: stoplight/prism:4
+    command: 'mock -h 0.0.0.0 /tmp/api.yaml'
+    volumes:
+      - ./studio.yaml:/tmp/api.yaml:ro
+    ports:
+      - '8020:4010'
+

--- a/test_resource/config/config.json
+++ b/test_resource/config/config.json
@@ -1,0 +1,28 @@
+{
+  "did": "did:nodex:test:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "key_pairs": {
+    "sign": {
+      "public_key": "0499d98e367a974f806655b21bfc7fd7121c5233d49c4025a79e9556da90a2822bbfb73edb21ab2da44d5d780eea7dfd4185294dc7d8763f7b782897ea5c235c44",
+      "secret_key": "85ac8afcb5fb9e184cf28d26d826d519219e7591d76aa4e7f610b98cda595e4c"
+    },
+    "update": {
+      "public_key": "0496c2cf63c382f53c85aebeb8bf74fe79ef7b8720807ce02e23e587bd69673d99a0e9111de68e0e392940bac15f525bd1b8bcbec9aa7caa1a69d2c2b087c49402",
+      "secret_key": "7847f29fc69fc3879d9a39fdbc44db496fcee8202093cf011ca4823b0690531a"
+    },
+    "recover": {
+      "public_key": "04ee117aeb34d9917055526682bf5e6dfcf2cbc7c4e041dc4bb3f9614ebd8ba3d3af2bf58023a099c89c39069ca8c574675694451b717713b6ceb62c38d0778faa",
+      "secret_key": "be0f0b0c520894cdfeb15b0a0d7eef4c34a74ced9e57a08f7026d36c3cfe135e"
+    },
+    "encrypt": {
+      "public_key": "043e1f7f6de487eafb2f70435051bd3c81e35507cf9cc0464006e4cf34e68bf7598b9584b37f7e219198d792c26edb728d05995b3a6eb154f51390971949828b1b",
+      "secret_key": "321edfadc634f8cfcc7f7ecff61504bc536ff7ecae5cfed16ef2ca9739b90468"
+    }
+  },
+  "extensions": {
+    "trng": null,
+    "secure_keystore": null,
+    "cipher": null
+  },
+  "is_initialized": true,
+  "schema_version": 1
+}

--- a/test_resource/config/network.json
+++ b/test_resource/config/network.json
@@ -1,0 +1,7 @@
+{
+  "secret_key": "secret_key",
+  "project_did": "project_did",
+  "recipient_dids": null,
+  "hub_endpoint": null,
+  "heartbeat": null
+}

--- a/test_resource/did_sidetree.yaml
+++ b/test_resource/did_sidetree.yaml
@@ -1,0 +1,169 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: DID Registry API
+servers:
+  - url: https://did.nodecross.io
+paths:
+  /api/v1/identifiers/{did}:
+    get:
+      summary: Find a did
+      operationId: findDID
+      tags:
+        - did
+      parameters:
+        - name: did
+          in: path
+          required: true
+          description: The did to retrieve
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DidResolutionResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/v1/operations:
+    post:
+      summary: Create a new did
+      operationId: createDID
+      tags:
+        - did
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DidCreateRequest"
+      responses:
+        "201":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DidResolutionResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    DidResolutionResponse:
+      type: object
+      required:
+        - "@context"
+        - didDocument
+        - methodMetadata
+      properties:
+        "@context":
+          type: string
+          example: "https://www.w3.org/ns/did-resolution/v1"
+        didDocument:
+          $ref: "#/components/schemas/DidDocument"
+        methodMetadata:
+          $ref: "#/components/schemas/methodMetadata"
+
+    DidDocument:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: "did:nodex:test:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        publicKey:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublicKey"
+        authentication:
+          type: array
+          items:
+            type: string
+          example: ["#signingKey"]
+
+    PublicKey:
+      type: object
+      required:
+        - id
+        - type
+        - controller
+        - publicKeyJwk
+      properties:
+        id:
+          type: string
+          example: "did:nodex:test:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA#signingKey"
+        controller:
+          type: string
+          example: ""
+        type:
+          type: string
+          example: "EcdsaSecp256k1VerificationKey2019"
+        publicKeyJwk:
+          $ref: "#/components/schemas/PublicKeyJwk"
+
+    PublicKeyJwk:
+      type: object
+      required:
+        - kty
+        - crv
+        - x
+        - y
+      properties:
+        kty:
+          type: string
+          example: "EC"
+        crv:
+          type: string
+          example: "secp256k1"
+        x:
+          type: string
+          example: "mdmONnqXT4BmVbIb_H_XEhxSM9ScQCWnnpVW2pCigis"
+        y:
+          type: string
+          example: "v7c-2yGrLaRNXXgO6n39QYUpTcfYdj97eCiX6lwjXEQ"
+
+    methodMetadata:
+      type: object
+      properties:
+        published:
+          type: boolean
+        recoveryCommitment:
+          type: string
+        updateCommitment:
+          type: string
+
+    DidCreateRequest:
+      type: object
+      required:
+        - type
+        - delta
+        - suffix_data
+      properties:
+        type:
+          type: string
+        delta:
+          type: string
+        suffix_data:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string

--- a/test_resource/studio.yaml
+++ b/test_resource/studio.yaml
@@ -1,0 +1,179 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Hub API
+servers:
+  - url: http://http.hub.nodecross.io
+paths:
+  /v1/device:
+    post:
+      summary: Register a new device
+      operationId: registerDevice
+      tags:
+        - device
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterDeviceRequest"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/device-info:
+    post:
+      summary: Send device info
+      operationId: sendDeviceInfo
+      tags:
+        - device
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceInfoRequest"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /v1/message/list:
+    post:
+      summary: List messages
+      operationId: listMessages
+      tags:
+        - message
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DidCommMessage"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageListResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    RegisterDeviceRequest:
+      type: object
+      required:
+        - device_did
+        - project_did
+      properties:
+        device_did:
+          type: string
+        project_did:
+          type: string
+
+    DeviceInfoRequest:
+      type: object
+      properties:
+        did:
+          type: string
+
+    EmptyResponse:
+      type: object
+
+    DidCommMessage:
+      type: object
+      properties:
+        ciphertext:
+          type: string
+        iv:
+          type: string
+        protected:
+          type: string
+        recipients:
+          type: array
+          items:
+            $ref: "#/components/schemas/Recipient"
+          example: []
+
+    Recipient:
+      type: object
+      properties:
+        encrypted_key:
+          type: string
+        header:
+          $ref: "#/components/schemas/RecipientHeader"
+
+    RecipientHeader:
+      type: object
+      properties:
+        alg:
+          type: string
+        epk:
+          $ref: "#/components/schemas/Epk"
+        iv:
+          type: string
+        key_ops:
+          type: array
+          items:
+            type: string
+        kid:
+          type: string
+        tag:
+          type: string
+
+    Epk:
+      type: object
+      properties:
+        crv:
+          type: string
+        kty:
+          type: string
+        x:
+          type: string
+
+    MessageListResponse:
+      type: array
+      items:
+        $ref: "#/components/schemas/MessageResponse"
+      example: []
+
+    MessageResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        raw_message:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string


### PR DESCRIPTION
## Description

- Implementation of a verifiable message api, except for sending message activities to Studio.
- Add e2e test scenario for a create-verifiable-message api and a verify-verifiable-message api.
- Add OpenAPI yaml to run mock server of NodeX Studio and SideTree.
- Add docker compose to run mock server.

## Check

- [x] Run E2E Test.
- [x] Verify check with curl

You can check with following command.
```
curl -v --unix-socket ~/.nodex/run/nodex.sock \
-X POST \
-H "Content-Type: application/json" \
-d '{"message": "received from create api" }' \
http://localhost/verify-verifiable-message
```

Here is my result.

```
MESSAGE=$(curl --unix-socket ~/.nodex/run/nodex.sock \
-X POST \
-H "Content-Type: application/json" \
-d '{"destination_did" : "did:nodex:test:EiD_ZSrS4E4FZruAIJnMt1KjvH1HvwCRYdnIzYpQr4vsuQ" , "message" : "test"}' \
http://localhost/create-verifiable-message)

echo $MESSAGE | jaq .
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1"
  ],
  "credentialSubject": {
    "container": {
      "created_at": "2024-02-10T10:39:45.034719+00:00",
      "destination_did": "did:nodex:test:EiD_ZSrS4E4FZruAIJnMt1KjvH1HvwCRYdnIzYpQr4vsuQ",
      "message_id": "0df7e86f-4f3c-4239-8cda-4faa11d461ad",
      "payload": "test",
      "project_hmac": "69e49a9a6f03b14ab6d702dc960110e70ae2c64e73a9badd641b54d0f28efef3"
    }
  },
  "issuanceDate": "2024-02-10T10:39:45.034719+00:00",
  "issuer": {
    "id": "did:nodex:test:EiDEp_0NuvczSI9n-8B5NmQoBQX__QORK-uZOhRs2zc_6A"
  },
  "proof": {
    "challenge": null,
    "controller": null,
    "created": "2024-02-10T10:39:45.039202+00:00",
    "domain": null,
    "jws": "eyJhbGciOiJFUzI1NksiLCJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdfQ..dL3Gy5qZb3tJ7j7WlGH3lhlGey2s-X5GcVHh7gUf6wI2f7lRrrweCYbXIAIFg4aernE909G7WVS8iXr-kmnNEg",
    "proofPurpose": "authentication",
    "type": "EcdsaSecp256k1Signature2019",
    "verificationMethod": "did:nodex:test:EiDEp_0NuvczSI9n-8B5NmQoBQX__QORK-uZOhRs2zc_6A#signingKey"
  },
  "type": [
    "VerifiableCredential"
  ]
}

BODY=$(jaq -n --arg message $MESSAGE '$ARGS.named')

curl -v --unix-socket ~/.nodex/run/nodex.sock \
-X POST \
-H "Content-Type: application/json" \
-d  $BODY \
http://localhost/verify-verifiable-message
```
