### PR TITLE
feat: send message activities to studio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,6 +4358,7 @@ checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom 0.2.7",
  "rand 0.8.5",
+ "serde",
  "uuid-macro-internal",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,12 @@ clap = { version = "4.0.18", features = ["derive", "cargo"] }
 dirs = { version = "5.0.0" }
 rumqttc = { version = "0.20.0" }
 cuid = { version = "1.3.1" }
-uuid = { version = "1.7.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+uuid = { version = "1.7.0", features = [
+  "v4",
+  "fast-rng",
+  "macro-diagnostics",
+  "serde",
+] }
 shadow-rs = "0.21.0"
 dotenv = "0.15.0"
 mac_address = "1.1.5"

--- a/e2e/tests/test_verifiable_message.rs
+++ b/e2e/tests/test_verifiable_message.rs
@@ -35,6 +35,7 @@ async fn create_verifiable_message_scenario() -> anyhow::Result<String> {
 
     let body = json!({
         "destination_did": my_did,
+        "operation_tag": "test",
         "message": "Hello, world!"
     })
     .to_string();

--- a/src/controllers/public/nodex_verify_verifiable_message.rs
+++ b/src/controllers/public/nodex_verify_verifiable_message.rs
@@ -1,7 +1,8 @@
 use actix_web::{web, HttpRequest, HttpResponse};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use crate::usecase::verifiable_message_usecase::VerifiableMessageUseCase;
+use crate::{services::hub::Hub, usecase::verifiable_message_usecase::VerifiableMessageUseCase};
 use crate::{
     services::{
         internal::did_vc::DIDVCService, nodex::NodeX,
@@ -20,13 +21,16 @@ pub async fn handler(
     _req: HttpRequest,
     web::Json(json): web::Json<MessageContainer>,
 ) -> actix_web::Result<HttpResponse> {
+    let now = Utc::now();
+
     let usecase = VerifiableMessageUseCase::new(
         Box::new(ProjectVerifierImplOnNetworkConfig::new()),
         Box::new(NodeX::new()),
+        Box::new(Hub::new()),
         DIDVCService::new(NodeX::new()),
     );
 
-    match usecase.verify(&json.message).await {
+    match usecase.verify(&json.message, now).await {
         Ok(v) => Ok(HttpResponse::Ok().body(v)),
         Err(e) => match e {
             VerifyVerifiableMessageUseCaseError::VerificationFailed => {

--- a/src/controllers/public/nodex_verify_verifiable_message.rs
+++ b/src/controllers/public/nodex_verify_verifiable_message.rs
@@ -36,6 +36,9 @@ pub async fn handler(
             VerifyVerifiableMessageUseCaseError::VerificationFailed => {
                 Ok(HttpResponse::Unauthorized().finish())
             }
+            VerifyVerifiableMessageUseCaseError::NotAddressedToMe => {
+                Ok(HttpResponse::Forbidden().finish())
+            }
             VerifyVerifiableMessageUseCaseError::Other(e) => {
                 log::error!("{:?}", e);
                 Ok(HttpResponse::InternalServerError().finish())

--- a/src/nodex/utils/hub_client.rs
+++ b/src/nodex/utils/hub_client.rs
@@ -180,11 +180,16 @@ impl HubClient {
         self.post(path, &payload).await
     }
 
-    #[allow(dead_code)]
-    pub async fn put(&self, _path: &str) -> anyhow::Result<reqwest::Response> {
-        let url = self.base_url.join(_path)?;
+    pub async fn put(&self, path: &str, body: &str) -> anyhow::Result<reqwest::Response> {
+        let url = self.base_url.join(path)?;
         let headers = self.auth_headers("".to_string())?;
-        let response = self.instance.put(url).headers(headers).send().await?;
+        let response = self
+            .instance
+            .put(url)
+            .headers(headers)
+            .body(body.to_string())
+            .send()
+            .await?;
 
         Ok(response)
     }
@@ -271,7 +276,7 @@ pub mod tests {
             Err(_) => panic!(),
         };
 
-        let res = match client.put("/put").await {
+        let res = match client.put("/put", r#"{"key":"value"}"#).await {
             Ok(v) => v,
             Err(_) => panic!(),
         };

--- a/src/repository/message_activity_repository.rs
+++ b/src/repository/message_activity_repository.rs
@@ -1,0 +1,38 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CreatedMessageActivityRequest {
+    pub message_id: Uuid,
+    pub from: String,
+    pub to: String,
+    pub operation_tag: String,
+    pub is_encrypted: bool,
+    pub occurred_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct VerifiedMessageActivityRequest {
+    pub message_id: Uuid,
+    pub verified_at: DateTime<Utc>,
+    pub status: VerifiedStatus,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub enum VerifiedStatus {
+    Valid,
+    Invalid,
+}
+
+#[async_trait::async_trait]
+pub trait MessageActivityRepository {
+    async fn add_create_activity(
+        &self,
+        request: CreatedMessageActivityRequest,
+    ) -> anyhow::Result<()>;
+    async fn add_verify_activity(
+        &self,
+        request: VerifiedMessageActivityRequest,
+    ) -> anyhow::Result<()>;
+}

--- a/src/repository/message_activity_repository.rs
+++ b/src/repository/message_activity_repository.rs
@@ -14,6 +14,8 @@ pub struct CreatedMessageActivityRequest {
 
 #[derive(Clone, Debug, Serialize)]
 pub struct VerifiedMessageActivityRequest {
+    pub from: String,
+    pub to: String,
     pub message_id: Uuid,
     pub verified_at: DateTime<Utc>,
     pub status: VerifiedStatus,

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,1 +1,2 @@
 pub mod did_repository;
+pub mod message_activity_repository;

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -1,8 +1,17 @@
-use crate::nodex::utils::hub_client::{HubClient, HubClientConfig};
 use crate::server_config;
+use crate::{
+    nodex::utils::hub_client::{HubClient, HubClientConfig},
+    repository::message_activity_repository::{
+        CreatedMessageActivityRequest, MessageActivityRepository, VerifiedMessageActivityRequest,
+    },
+};
 
+use anyhow::Context;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use super::internal::didcomm_encrypted::DIDCommEncryptedService;
 
 #[derive(Deserialize)]
 pub struct EmptyResponse {}
@@ -239,6 +248,89 @@ impl Hub {
                 Err(e) => anyhow::bail!("StatusCode=400, but parse failed. {:?}", e),
             },
             other => anyhow::bail!("StatusCode={other}, unexpected response"),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl MessageActivityRepository for Hub {
+    async fn add_create_activity(
+        &self,
+        request: CreatedMessageActivityRequest,
+    ) -> anyhow::Result<()> {
+        let project_did = {
+            let network = crate::network_config();
+            let network = network.lock();
+            network.get_project_did().expect("project_did is not set")
+        };
+        let payload = DIDCommEncryptedService::generate(
+            &project_did,
+            &json!(request),
+            None,
+            request.occurred_at,
+        )
+        .await?;
+        let payload = serde_json::to_string(&payload).context("failed to serialize")?;
+
+        let res = self
+            .http_client
+            .post("/v1/message_activity", &payload)
+            .await?;
+
+        match res.status() {
+            reqwest::StatusCode::OK => {
+                res.json::<EmptyResponse>().await?;
+                Ok(())
+            }
+            reqwest::StatusCode::BAD_REQUEST => {
+                anyhow::bail!("StatusCode=400, bad request")
+            }
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                anyhow::bail!("StatusCode=500, internal server error");
+            }
+            other => {
+                anyhow::bail!("StatusCode={other}, unexpected response");
+            }
+        }
+    }
+
+    async fn add_verify_activity(
+        &self,
+        request: VerifiedMessageActivityRequest,
+    ) -> anyhow::Result<()> {
+        let project_did = {
+            let network = crate::network_config();
+            let network = network.lock();
+            network.get_project_did().expect("project_did is not set")
+        };
+        let payload = DIDCommEncryptedService::generate(
+            &project_did,
+            &json!(request),
+            None,
+            request.verified_at,
+        )
+        .await?;
+        let payload = serde_json::to_string(&payload).context("failed to serialize")?;
+
+        let res = self
+            .http_client
+            .put("/v1/message_activity", &payload)
+            .await?;
+
+        match res.status() {
+            reqwest::StatusCode::OK => {
+                res.json::<EmptyResponse>().await?;
+                Ok(())
+            }
+            reqwest::StatusCode::BAD_REQUEST => {
+                anyhow::bail!("StatusCode=400, bad request")
+            }
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                anyhow::bail!("StatusCode=500, internal server error");
+            }
+            other => {
+                anyhow::bail!("StatusCode={other}, unexpected response");
+            }
         }
     }
 }

--- a/src/usecase/verifiable_message_usecase.rs
+++ b/src/usecase/verifiable_message_usecase.rs
@@ -1,5 +1,5 @@
 use crate::{
-    repository::did_repository::DidRepository,
+    repository::{did_repository::DidRepository, message_activity_repository::*},
     services::{internal::did_vc::DIDVCService, project_verifier::ProjectVerifier},
 };
 use anyhow::Context;
@@ -14,6 +14,7 @@ use uuid::Uuid;
 pub struct VerifiableMessageUseCase {
     project_verifier: Box<dyn ProjectVerifier>,
     did_repository: Box<dyn DidRepository>,
+    message_activity_repository: Box<dyn MessageActivityRepository>,
     vc_service: DIDVCService,
 }
 
@@ -21,11 +22,13 @@ impl VerifiableMessageUseCase {
     pub fn new(
         project_verifier: Box<dyn ProjectVerifier>,
         did_repository: Box<dyn DidRepository>,
+        message_activity_repository: Box<dyn MessageActivityRepository>,
         vc_service: DIDVCService,
     ) -> Self {
         Self {
             project_verifier,
             did_repository,
+            message_activity_repository,
             vc_service,
         }
     }
@@ -52,6 +55,7 @@ impl VerifiableMessageUseCase {
         &self,
         destination_did: String,
         message: String,
+        operation_tag: String,
         now: DateTime<Utc>,
     ) -> Result<String, CreateVerifiableMessageUseCaseError> {
         self.did_repository
@@ -59,8 +63,14 @@ impl VerifiableMessageUseCase {
             .await?
             .ok_or(CreateVerifiableMessageUseCaseError::DestinationNotFound)?;
 
+        let message_id = Uuid::new_v4();
+        let my_did = {
+            let config = crate::app_config();
+            let config = config.lock();
+            config.get_did().unwrap().to_string()
+        };
         let message = EncodedMessage {
-            message_id: Uuid::new_v4().to_string(),
+            message_id,
             payload: message,
             destination_did: destination_did.clone(),
             created_at: now.to_rfc3339(),
@@ -70,13 +80,27 @@ impl VerifiableMessageUseCase {
         let message = serde_json::to_value(message).context("failed to convert to value")?;
         let vc = DIDVCService::generate(&self.vc_service, &message, now)?;
 
-        Ok(serde_json::to_string(&vc).context("failed to serialize")?)
+        let result = serde_json::to_string(&vc).context("failed to serialize")?;
+
+        self.message_activity_repository
+            .add_create_activity(CreatedMessageActivityRequest {
+                message_id,
+                from: my_did,
+                to: destination_did,
+                operation_tag,
+                is_encrypted: false,
+                occurred_at: now,
+            })
+            .await
+            .context("failed to add create activity")?;
+
+        Ok(result)
     }
 
-    #[allow(dead_code)]
     pub async fn verify(
         &self,
         message: &str,
+        now: DateTime<Utc>,
     ) -> Result<String, VerifyVerifiableMessageUseCaseError> {
         let message = serde_json::from_str::<Value>(message).context("failed to decode str")?;
 
@@ -98,8 +122,24 @@ impl VerifiableMessageUseCase {
             .project_verifier
             .verify_project_hmac(&message.project_hmac)?
         {
+            self.message_activity_repository
+                .add_verify_activity(VerifiedMessageActivityRequest {
+                    message_id: message.message_id,
+                    verified_at: now,
+                    status: VerifiedStatus::Valid,
+                })
+                .await
+                .context("failed to add verify activity")?;
             Ok(message.payload)
         } else {
+            self.message_activity_repository
+                .add_verify_activity(VerifiedMessageActivityRequest {
+                    message_id: message.message_id,
+                    verified_at: now,
+                    status: VerifiedStatus::Invalid,
+                })
+                .await
+                .context("failed to add verify activity")?;
             Err(VerifyVerifiableMessageUseCaseError::VerificationFailed)
         }
     }
@@ -107,7 +147,7 @@ impl VerifiableMessageUseCase {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EncodedMessage {
-    pub message_id: String,
+    pub message_id: Uuid,
     pub payload: String,
     pub destination_did: String,
     pub created_at: String,
@@ -187,6 +227,25 @@ mod tests {
         }
     }
 
+    struct MockActivityRepository {}
+
+    #[async_trait::async_trait]
+    impl MessageActivityRepository for MockActivityRepository {
+        async fn add_create_activity(
+            &self,
+            _request: CreatedMessageActivityRequest,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn add_verify_activity(
+            &self,
+            _request: VerifiedMessageActivityRequest,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
     #[tokio::test]
     async fn test_create_and_verify() {
         // generate local did and keys
@@ -197,6 +256,7 @@ mod tests {
         let usecase = VerifiableMessageUseCase {
             project_verifier: Box::new(MockProjectVerifier {}),
             did_repository: Box::new(MockDidRepository {}),
+            message_activity_repository: Box::new(MockActivityRepository {}),
             vc_service: DIDVCService::new(MockDidRepository {}),
         };
 
@@ -205,7 +265,7 @@ mod tests {
 
         let now = Utc::now();
         let generated = usecase
-            .generate(destination_did, message.clone(), now)
+            .generate(destination_did, message.clone(), "test".to_string(), now)
             .await
             .unwrap();
 
@@ -227,98 +287,273 @@ mod tests {
             })
         );
 
-        let verified = usecase.verify(&generated).await.unwrap();
+        let verified = usecase.verify(&generated, Utc::now()).await.unwrap();
         assert_eq!(verified, message);
     }
 
-    #[tokio::test]
-    async fn test_generate_did_not_found() {
-        struct NotFoundDidRepository {}
+    mod generate_failed {
+        use super::*;
 
-        #[async_trait::async_trait]
-        impl DidRepository for NotFoundDidRepository {
-            async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse> {
-                unreachable!()
+        #[tokio::test]
+        async fn test_generate_did_not_found() {
+            struct NotFoundDidRepository {}
+
+            #[async_trait::async_trait]
+            impl DidRepository for NotFoundDidRepository {
+                async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse> {
+                    unreachable!()
+                }
+                async fn find_identifier(
+                    &self,
+                    _did: &str,
+                ) -> anyhow::Result<Option<DIDResolutionResponse>> {
+                    Ok(None)
+                }
             }
-            async fn find_identifier(
-                &self,
-                _did: &str,
-            ) -> anyhow::Result<Option<DIDResolutionResponse>> {
-                Ok(None)
+
+            let usecase = VerifiableMessageUseCase {
+                project_verifier: Box::new(MockProjectVerifier {}),
+                did_repository: Box::new(NotFoundDidRepository {}),
+                message_activity_repository: Box::new(MockActivityRepository {}),
+                vc_service: DIDVCService::new(MockDidRepository {}),
+            };
+
+            let destination_did = "did:example:123".to_string();
+            let message = "Hello".to_string();
+
+            let now = Utc::now();
+            let generated = usecase
+                .generate(destination_did, message, "test".to_string(), now)
+                .await;
+
+            if let Err(CreateVerifiableMessageUseCaseError::DestinationNotFound) = generated {
+            } else {
+                panic!("unexpected result: {:?}", generated);
             }
         }
 
-        let usecase = VerifiableMessageUseCase {
-            project_verifier: Box::new(MockProjectVerifier {}),
-            did_repository: Box::new(NotFoundDidRepository {}),
-            vc_service: DIDVCService::new(MockDidRepository {}),
-        };
+        #[tokio::test]
+        async fn test_generate_create_project_hmac_failed() {
+            struct CreateProjectHmacFailedVerifier {}
 
-        let destination_did = "did:example:123".to_string();
-        let message = "Hello".to_string();
+            impl ProjectVerifier for CreateProjectHmacFailedVerifier {
+                fn create_project_hmac(&self) -> anyhow::Result<String> {
+                    Err(anyhow::anyhow!("create project hmac failed"))
+                }
+                fn verify_project_hmac(&self, _signature: &str) -> anyhow::Result<bool> {
+                    unreachable!()
+                }
+            }
 
-        let now = Utc::now();
-        let generated = usecase.generate(destination_did, message, now).await;
+            let usecase = VerifiableMessageUseCase {
+                project_verifier: Box::new(CreateProjectHmacFailedVerifier {}),
+                did_repository: Box::new(MockDidRepository {}),
+                message_activity_repository: Box::new(MockActivityRepository {}),
+                vc_service: DIDVCService::new(MockDidRepository {}),
+            };
 
-        if let Err(CreateVerifiableMessageUseCaseError::DestinationNotFound) = generated {
-        } else {
-            panic!("unexpected result: {:?}", generated);
+            let destination_did = "did:example:123".to_string();
+            let message = "Hello".to_string();
+
+            let now = Utc::now();
+            let generated = usecase
+                .generate(destination_did, message, "test".to_string(), now)
+                .await;
+
+            if let Err(CreateVerifiableMessageUseCaseError::Other(_)) = generated {
+            } else {
+                panic!("unexpected result: {:?}", generated);
+            }
+        }
+
+        #[tokio::test]
+        async fn test_generate_add_activity_failed() {
+            struct CreateActivityFailedRepository {}
+
+            #[async_trait::async_trait]
+            impl MessageActivityRepository for CreateActivityFailedRepository {
+                async fn add_create_activity(
+                    &self,
+                    _request: CreatedMessageActivityRequest,
+                ) -> anyhow::Result<()> {
+                    Err(anyhow::anyhow!("create activity failed"))
+                }
+
+                async fn add_verify_activity(
+                    &self,
+                    _request: VerifiedMessageActivityRequest,
+                ) -> anyhow::Result<()> {
+                    unreachable!()
+                }
+            }
+
+            let usecase = VerifiableMessageUseCase {
+                project_verifier: Box::new(MockProjectVerifier {}),
+                did_repository: Box::new(MockDidRepository {}),
+                message_activity_repository: Box::new(CreateActivityFailedRepository {}),
+                vc_service: DIDVCService::new(MockDidRepository {}),
+            };
+
+            let destination_did = "did:example:123".to_string();
+            let message = "Hello".to_string();
+
+            let now = Utc::now();
+            let generated = usecase
+                .generate(destination_did, message, "test".to_string(), now)
+                .await;
+
+            if let Err(CreateVerifiableMessageUseCaseError::Other(_)) = generated {
+            } else {
+                panic!("unexpected result: {:?}", generated);
+            }
         }
     }
 
-    #[tokio::test]
-    async fn test_verify_verify_failed() {
-        // generate local did and keys
-        let repository = MockDidRepository {};
-        repository.create_identifier().await.unwrap();
+    mod verify_failed {
+        use super::*;
 
-        struct VerifyFailedVerifier {}
+        async fn create_test_message_for_verify_test() -> String {
+            let usecase = VerifiableMessageUseCase {
+                project_verifier: Box::new(MockProjectVerifier {}),
+                did_repository: Box::new(MockDidRepository {}),
+                message_activity_repository: Box::new(MockActivityRepository {}),
+                vc_service: DIDVCService::new(MockDidRepository {}),
+            };
 
-        impl ProjectVerifier for VerifyFailedVerifier {
-            fn create_project_hmac(&self) -> anyhow::Result<String> {
-                Ok("mock".to_string())
+            let destination_did = "did:example:123".to_string();
+            let message = "Hello".to_string();
+
+            let now = Utc::now();
+            let generated = usecase
+                .generate(destination_did, message.clone(), "test".to_string(), now)
+                .await
+                .unwrap();
+
+            let result: Value = serde_json::from_str(&generated).unwrap();
+
+            let message_id = result["credentialSubject"]["container"]["message_id"]
+                .as_str()
+                .unwrap();
+
+            assert_eq!(
+                result["credentialSubject"]["container"],
+                serde_json::json!({
+                    "message_id": message_id,
+                    "payload": "Hello",
+                    "destination_did": "did:example:123",
+                    "created_at": now.to_rfc3339(),
+                    "project_hmac": "mock"
+                })
+            );
+
+            generated
+        }
+
+        #[tokio::test]
+        async fn test_verify_verify_failed() {
+            // generate local did and keys
+            let repository = MockDidRepository {};
+            repository.create_identifier().await.unwrap();
+
+            struct VerifyFailedVerifier {}
+
+            impl ProjectVerifier for VerifyFailedVerifier {
+                fn create_project_hmac(&self) -> anyhow::Result<String> {
+                    Ok("mock".to_string())
+                }
+                fn verify_project_hmac(&self, _signature: &str) -> anyhow::Result<bool> {
+                    Ok(false)
+                }
             }
-            fn verify_project_hmac(&self, _signature: &str) -> anyhow::Result<bool> {
-                Ok(false)
+
+            let usecase = VerifiableMessageUseCase {
+                project_verifier: Box::new(VerifyFailedVerifier {}),
+                did_repository: Box::new(MockDidRepository {}),
+                message_activity_repository: Box::new(MockActivityRepository {}),
+                vc_service: DIDVCService::new(MockDidRepository {}),
+            };
+
+            let generated = create_test_message_for_verify_test().await;
+            let verified = usecase.verify(&generated, Utc::now()).await;
+
+            if let Err(VerifyVerifiableMessageUseCaseError::VerificationFailed) = verified {
+            } else {
+                panic!("unexpected result: {:?}", generated);
             }
         }
 
-        let usecase = VerifiableMessageUseCase {
-            project_verifier: Box::new(VerifyFailedVerifier {}),
-            did_repository: Box::new(MockDidRepository {}),
-            vc_service: DIDVCService::new(MockDidRepository {}),
-        };
+        #[tokio::test]
+        async fn test_verify_did_not_found() {
+            // generate local did and keys
+            let repository = MockDidRepository {};
+            repository.create_identifier().await.unwrap();
 
-        let destination_did = "did:example:123".to_string();
-        let message = "Hello".to_string();
+            struct NotFoundDidRepository {}
 
-        let now = Utc::now();
-        let generated = usecase
-            .generate(destination_did, message.clone(), now)
-            .await
-            .unwrap();
+            #[async_trait::async_trait]
+            impl DidRepository for NotFoundDidRepository {
+                async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse> {
+                    unreachable!()
+                }
+                async fn find_identifier(
+                    &self,
+                    _did: &str,
+                ) -> anyhow::Result<Option<DIDResolutionResponse>> {
+                    Ok(None)
+                }
+            }
 
-        let result: Value = serde_json::from_str(&generated).unwrap();
+            let usecase = VerifiableMessageUseCase {
+                project_verifier: Box::new(MockProjectVerifier {}),
+                did_repository: Box::new(MockDidRepository {}),
+                message_activity_repository: Box::new(MockActivityRepository {}),
+                vc_service: DIDVCService::new(NotFoundDidRepository {}),
+            };
 
-        let message_id = result["credentialSubject"]["container"]["message_id"]
-            .as_str()
-            .unwrap();
+            let generated = create_test_message_for_verify_test().await;
+            let verified = usecase.verify(&generated, Utc::now()).await;
 
-        assert_eq!(
-            result["credentialSubject"]["container"],
-            serde_json::json!({
-                "message_id": message_id,
-                "payload": "Hello",
-                "destination_did": "did:example:123",
-                "created_at": now.to_rfc3339(),
-                "project_hmac": "mock"
-            })
-        );
-        let verified = usecase.verify(&generated).await;
+            if let Err(VerifyVerifiableMessageUseCaseError::Other(_)) = verified {
+            } else {
+                panic!("unexpected result: {:?}", generated);
+            }
+        }
 
-        if let Err(VerifyVerifiableMessageUseCaseError::VerificationFailed) = verified {
-        } else {
-            panic!("unexpected result: {:?}", generated);
+        #[tokio::test]
+        async fn test_verify_add_activity_failed() {
+            struct VerifyActivityFailedRepository {}
+
+            #[async_trait::async_trait]
+            impl MessageActivityRepository for VerifyActivityFailedRepository {
+                async fn add_create_activity(
+                    &self,
+                    _request: CreatedMessageActivityRequest,
+                ) -> anyhow::Result<()> {
+                    unreachable!()
+                }
+
+                async fn add_verify_activity(
+                    &self,
+                    _request: VerifiedMessageActivityRequest,
+                ) -> anyhow::Result<()> {
+                    Err(anyhow::anyhow!("verify activity failed"))
+                }
+            }
+
+            let usecase = VerifiableMessageUseCase {
+                project_verifier: Box::new(MockProjectVerifier {}),
+                did_repository: Box::new(MockDidRepository {}),
+                message_activity_repository: Box::new(VerifyActivityFailedRepository {}),
+                vc_service: DIDVCService::new(MockDidRepository {}),
+            };
+
+            let generated = create_test_message_for_verify_test().await;
+            let verified = usecase.verify(&generated, Utc::now()).await;
+
+            if let Err(VerifyVerifiableMessageUseCaseError::Other(_)) = verified {
+            } else {
+                panic!("unexpected result: {:?}", generated);
+            }
         }
     }
 }

--- a/test_resource/studio.yaml
+++ b/test_resource/studio.yaml
@@ -80,6 +80,54 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /v1/message_activity:
+    post:
+      summary: Send message activity
+      operationId: sendMessageActivity
+      tags:
+        - message
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DidCommMessage"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    put:
+      summary: Send message activity
+      operationId: sendMessageActivity
+      tags:
+        - message
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DidCommMessage"
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmptyResponse"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 components:
   schemas:
     RegisterDeviceRequest:


### PR DESCRIPTION
## Description

We want to send message activities to Studio when the api `create-verifiable-message` `verify-verifiable-message` called.

I also added a test case for UseCase failure.

## Check 

- [x] E2E Test only
  - This is because these APIs in the studio are still being implemented.