### PR TITLE
chore: build linux binary using cross

### DIFF
--- a/.github/actions/build-with-cross/action.yml
+++ b/.github/actions/build-with-cross/action.yml
@@ -1,4 +1,4 @@
-name: build
+name: build with cross
 description: ""
 inputs:
   target:
@@ -24,9 +24,15 @@ runs:
       if: ${{ inputs.use-cache == 'true' }}
       uses: Swatinem/rust-cache@v2
 
+    - uses: cargo-bins/cargo-binstall@main
+
+    - name: (setup) install cross
+      shell: bash
+      run: cargo binstall cross
+
     - name: (run) build
       shell: bash
-      run: cargo build --release
+      run: cross build --target aarch64-unknown-linux-gnu --release
 
     - name: (run) create artifact
       uses: vimtor/action-zip@v1.1

--- a/.github/actions/build-with-cross/action.yml
+++ b/.github/actions/build-with-cross/action.yml
@@ -41,7 +41,7 @@ runs:
         dest: nodex-agent-${{ inputs.target }}.zip
 
     - name: (run) upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.target }}
         path: nodex-agent-${{ inputs.target }}.zip

--- a/.github/actions/build-with-cross/action.yml
+++ b/.github/actions/build-with-cross/action.yml
@@ -24,11 +24,10 @@ runs:
       if: ${{ inputs.use-cache == 'true' }}
       uses: Swatinem/rust-cache@v2
 
-    - uses: cargo-bins/cargo-binstall@main
-
-    - name: (setup) install cross
-      shell: bash
-      run: cargo binstall cross
+    - name: (install) install development tools
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-llvm-cov,cross
 
     - name: (run) build
       shell: bash

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -25,9 +25,10 @@ runs:
       shell: bash
       run: rustup component add llvm-tools-preview
 
-    - name: (install) cargo-llvm-cov
-      shell: bash
-      run: cargo install cargo-llvm-cov
+    - name: (install) install development tools
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-llvm-cov
 
     - name: (setup) copy default config to home
       shell: bash

--- a/.github/workflows/default-pipeline.yml
+++ b/.github/workflows/default-pipeline.yml
@@ -2,7 +2,7 @@ name: default-pipeline
 
 on:
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,42 +16,60 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: (checkout) source code
-      uses: actions/checkout@v3
+      - name: (checkout) source code
+        uses: actions/checkout@v3
 
-    - name: (run) lint
-      uses: ./.github/actions/lint
-      with:
-        github-token: ${{ env.GITHUB_TOKEN }}
-        use-cache: true
+      - name: (run) lint
+        uses: ./.github/actions/lint
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          use-cache: true
 
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - name: (checkout) source code
-      uses: actions/checkout@v3
+      - name: (checkout) source code
+        uses: actions/checkout@v3
 
-    - name: (run) test
-      uses: ./.github/actions/test
-      with:
-        github-token: ${{ env.GITHUB_TOKEN }}
-        use-cache: true
+      - name: (run) test
+        uses: ./.github/actions/test
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          use-cache: true
 
-  build:
+  build-macos:
+    name: Build / MacOS
+    runs-on: macos-latest
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-
-    runs-on: ${{ matrix.os }}
+        target: [x86_64-apple-darwin]
 
     steps:
-    - name: (checkout) source code
-      uses: actions/checkout@v3
+      - name: (checkout) source code
+        uses: actions/checkout@v3
 
-    - name: (run) build
-      uses: ./.github/actions/build
-      with:
-        os: ${{ matrix.os }}
-        use-cache: true
-        github-token: ${{ env.GITHUB_TOKEN }}
+      - name: (run) build
+        uses: ./.github/actions/build
+        with:
+          target: ${{ matrix.target }}
+          use-cache: true
+          github-token: ${{ env.GITHUB_TOKEN }}
+
+  build-linux:
+    name: Build / Linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64-unknown-linux-gnu]
+
+    steps:
+      - name: (checkout) source code
+        uses: actions/checkout@v3
+
+      - name: (run) build
+        uses: ./.github/actions/build
+        with:
+          target: ${{ matrix.target }}
+          use-cache: true
+          github-token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/default-pipeline.yml
+++ b/.github/workflows/default-pipeline.yml
@@ -39,11 +39,11 @@ jobs:
           use-cache: true
 
   build-macos:
-    name: Build / MacOS
     runs-on: macos-latest
     strategy:
       matrix:
         target: [x86_64-apple-darwin]
+    name: Build / MacOS / ${{ matrix.target }}
 
     steps:
       - name: (checkout) source code
@@ -57,18 +57,18 @@ jobs:
           github-token: ${{ env.GITHUB_TOKEN }}
 
   build-linux:
-    name: Build / Linux
     runs-on: ubuntu-latest
     strategy:
       matrix:
         target: [x86_64-unknown-linux-gnu]
+    name: Build / Linux / ${{ matrix.target }}
 
     steps:
       - name: (checkout) source code
         uses: actions/checkout@v3
 
       - name: (run) build
-        uses: ./.github/actions/build
+        uses: ./.github/actions/build-with-cross
         with:
           target: ${{ matrix.target }}
           use-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,17 +77,15 @@ jobs:
           CARGO_TOML_VERSION=$(cargo get package.version)
           echo "version=$CARGO_TOML_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Download artifacts (mac)
-        uses: actions/download-artifact@v3
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: x86_64-apple-darwin
-          path: ~/x86_64-apple-darwin
+          path: ${{ github.workspace }}
+          merge-multiple: true
 
-      - name: Download artifacts (linux)
-        uses: actions/download-artifact@v3
-        with:
-          name: x86_64-unknown-linux-gnu
-          path: ~/x86_64-unknown-linux-gnu
+      - name: Check downloaded artifacts
+        run: |
+          ls -la ${{ github.workspace }}
 
       - name: Create Example asset
         shell: bash
@@ -115,7 +113,7 @@ jobs:
         uses: ./.github/actions/upload-release-asset
         with:
           release_id: ${{ steps.release.outputs.result }}
-          asset_path: /home/runner/ubuntu-latest/nodex-agent-x86_64-unknown-linux-gnu.zip
+          asset_path: ${{ github.workspace }}/nodex-agent-x86_64-unknown-linux-gnu.zip
           asset_name: nodex-agent-x86_64.zip
           asset_content_type: application/zip
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -124,7 +122,7 @@ jobs:
         uses: ./.github/actions/upload-release-asset
         with:
           release_id: ${{ steps.release.outputs.result }}
-          asset_path: /home/runner/macos-latest/nodex-agent-x86_64-apple-darwin.zip
+          asset_path: ${{ github.workspace }}/nodex-agent-x86_64-apple-darwin.zip
           asset_name: nodex-agent-mac.zip
           asset_content_type: application/zip
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
           github_token: ${{ secrets.PAT }}
 
   build-macos:
-    name: Build / MacOS
     needs: check-user
     runs-on: macos-latest
     strategy:
       matrix:
         target: [x86_64-apple-darwin]
+    name: Build / MacOS / ${{ matrix.target }}
     steps:
       - name: (checkout) source code
         uses: actions/checkout@v4
@@ -40,12 +40,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build-linux:
-    name: Build / Linux
     needs: check-user
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target: [aarch64-unknown-linux-gnu]
-    runs-on: ubuntu-latest
+    name: Build / Linux / ${{ matrix.target }}
     steps:
       - name: (checkout) source code
         uses: actions/checkout@v4
@@ -80,14 +80,14 @@ jobs:
       - name: Download artifacts (mac)
         uses: actions/download-artifact@v3
         with:
-          name: macos-latest
-          path: ~/macos-latest
+          name: x86_64-apple-darwin
+          path: ~/x86_64-apple-darwin
 
       - name: Download artifacts (linux)
         uses: actions/download-artifact@v3
         with:
-          name: ubuntu-latest
-          path: ~/ubuntu-latest
+          name: x86_64-unknown-linux-gnu
+          path: ~/x86_64-unknown-linux-gnu
 
       - name: Create Example asset
         shell: bash
@@ -115,7 +115,7 @@ jobs:
         uses: ./.github/actions/upload-release-asset
         with:
           release_id: ${{ steps.release.outputs.result }}
-          asset_path: /home/runner/ubuntu-latest/nodex-agent-ubuntu-latest.zip
+          asset_path: /home/runner/ubuntu-latest/nodex-agent-x86_64-unknown-linux-gnu.zip
           asset_name: nodex-agent-x86_64.zip
           asset_content_type: application/zip
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -124,7 +124,7 @@ jobs:
         uses: ./.github/actions/upload-release-asset
         with:
           release_id: ${{ steps.release.outputs.result }}
-          asset_path: /home/runner/macos-latest/nodex-agent-macos-latest.zip
+          asset_path: /home/runner/macos-latest/nodex-agent-x86_64-apple-darwin.zip
           asset_name: nodex-agent-mac.zip
           asset_content_type: application/zip
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
           actor: ${{ github.actor }}
           github_token: ${{ secrets.PAT }}
 
-  build:
-    name: Build
+  build-macos:
+    name: Build / MacOS
     needs: check-user
+    runs-on: macos-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+        target: [x86_64-apple-darwin]
     steps:
       - name: (checkout) source code
         uses: actions/checkout@v4
@@ -35,13 +35,31 @@ jobs:
       - name: (run) build
         uses: ./.github/actions/build
         with:
-          os: ${{ matrix.os }}
+          target: ${{ matrix.target }}
+          use-cache: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-linux:
+    name: Build / Linux
+    needs: check-user
+    strategy:
+      matrix:
+        target: [aarch64-unknown-linux-gnu]
+    runs-on: ubuntu-latest
+    steps:
+      - name: (checkout) source code
+        uses: actions/checkout@v4
+
+      - name: (run) build
+        uses: ./.github/actions/build-with-cross
+        with:
+          target: ${{ matrix.target }}
           use-cache: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: Release
-    needs: build
+    needs: [build-macos, build-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main-centos"
+
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos"


### PR DESCRIPTION
## Description

Currently, the linux binary built in the workflow on ubuntu-latest runner.
However, that OS has a high version of glibc, which creates binaries that do not work on some OS.

To fix this problem, we use cross to build binary in docker image `ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main-centos`.
That centos docker image uses glibc 2.17.
<img width="679" alt="image" src="https://github.com/nodecross/nodex/assets/30817722/7160e581-523b-4f0f-b47e-ca6fa167efb7">


https://github.com/cross-rs/cross