### PR TITLE
chore: fix target in build-linux job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [aarch64-unknown-linux-gnu]
+        target: [x86_64-unknown-linux-gnu]
     name: Build / Linux / ${{ matrix.target }}
     steps:
       - name: (checkout) source code


### PR DESCRIPTION
## Description

I made a mistake with the target value for the `build-linux` job.