### PR TITLE
fix: change binary path and build target

### DIFF
--- a/.github/actions/build-with-cross/action.yml
+++ b/.github/actions/build-with-cross/action.yml
@@ -31,12 +31,12 @@ runs:
 
     - name: (run) build
       shell: bash
-      run: cross build --target aarch64-unknown-linux-gnu --release
+      run: cross build --target ${{ inputs.target }} --release
 
     - name: (run) create artifact
       uses: vimtor/action-zip@v1.1
       with:
-        files: target/release/nodex-agent
+        files: target/${{ inputs.target }}/release/nodex-agent
         dest: nodex-agent-${{ inputs.target }}.zip
 
     - name: (run) upload artifact


### PR DESCRIPTION
## Description

The binary build in linux isn't uploaded when I checked this job.
https://github.com/nodecross/nodex/actions/runs/7941176716/job/21683246445

This was due to an incorrect target name in the `build-with-cross` step and an incorrect binary path.

## Check

I've checked the job result.
https://github.com/nodecross/nodex/actions/runs/7941404537/job/21683720004

<img width="898" alt="image" src="https://github.com/nodecross/nodex/assets/30817722/f557c9c5-fc72-4bef-a704-3ca0f5bea650">
