### PR TITLE
fix: update upload-artifact and tiny refactoring

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,16 +26,16 @@ runs:
 
     - name: (run) build
       shell: bash
-      run: cargo build --release
+      run: cargo build --release --target ${{ inputs.target }}
 
     - name: (run) create artifact
       uses: vimtor/action-zip@v1.1
       with:
-        files: target/release/nodex-agent
+        files: target/${{ inputs.target }}/release/nodex-agent
         dest: nodex-agent-${{ inputs.target }}.zip
 
     - name: (run) upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.target }}
         path: nodex-agent-${{ inputs.target }}.zip


### PR DESCRIPTION
## Description

The third party action `download-artifact@v4` can download assets uploaded using `upload-artifact@v4`.
I've update the version of that action.
