### PR TITLE
feat: implement create/verify didcomm message apis

### DIFF
--- a/e2e/tests/test_didcomm_message.rs
+++ b/e2e/tests/test_didcomm_message.rs
@@ -54,12 +54,7 @@ async fn create_didcomm_message_scenario() -> anyhow::Result<String> {
 
     let body = response_to_string(response).await?;
     // parse check
-    let parsed = serde_json::from_str::<serde_json::Value>(&body)?;
-    dbg!(&parsed);
-    assert_eq!(
-        parsed["credentialSubject"]["container"]["payload"],
-        "Hello, world!"
-    );
+    let _ = serde_json::from_str::<serde_json::Value>(&body)?;
 
     Ok(body)
 }

--- a/e2e/tests/test_didcomm_message.rs
+++ b/e2e/tests/test_didcomm_message.rs
@@ -1,0 +1,103 @@
+use http_body_util::BodyExt;
+use hyper::{body::Incoming, Method, Request, StatusCode};
+use hyper_util::client::legacy::Client;
+use hyperlocal::{UnixClientExt, UnixConnector, Uri as HyperLocalUri};
+use serde_json::json;
+use std::fs::read;
+use tokio::io::AsyncWriteExt as _;
+
+async fn response_to_string(mut response: hyper::Response<Incoming>) -> anyhow::Result<String> {
+    let mut body: Vec<u8> = Vec::with_capacity(2048);
+
+    while let Some(frame_result) = response.frame().await {
+        let frame = frame_result?;
+
+        if let Some(segment) = frame.data_ref() {
+            body.write_all(segment.iter().as_slice()).await?;
+        }
+    }
+
+    Ok(String::from_utf8(body)?)
+}
+
+async fn create_didcomm_message_scenario() -> anyhow::Result<String> {
+    let homedir = dirs::home_dir().unwrap();
+    let socket_path = homedir.join(".nodex/run/nodex.sock");
+    let client: Client<UnixConnector, _> = Client::unix();
+
+    let create_url = HyperLocalUri::new(&socket_path, "/create-didcomm-message");
+
+    let my_did = {
+        let config = read(homedir.join(".config/nodex/config.json"))?;
+        let config = serde_json::from_slice::<serde_json::Value>(&config)?;
+        config["did"].as_str().unwrap().to_string()
+    };
+
+    let body = json!({
+        "destination_did": my_did,
+        "operation_tag": "test",
+        "message": "Hello, world!"
+    })
+    .to_string();
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(create_url)
+        .header("Content-Type", "application/json")
+        .body(body)?;
+    dbg!(&request);
+
+    let response = client.request(request).await?;
+    dbg!(&response);
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response_to_string(response).await?;
+    // parse check
+    let parsed = serde_json::from_str::<serde_json::Value>(&body)?;
+    dbg!(&parsed);
+    assert_eq!(
+        parsed["credentialSubject"]["container"]["payload"],
+        "Hello, world!"
+    );
+
+    Ok(body)
+}
+
+async fn verify_didcomm_message_scenario(input: String) -> anyhow::Result<()> {
+    let homedir = dirs::home_dir().unwrap();
+    let socket_path = homedir.join(".nodex/run/nodex.sock");
+    let client: Client<UnixConnector, _> = Client::unix();
+
+    let verify_url = HyperLocalUri::new(&socket_path, "/verify-didcomm-message");
+
+    let body = json!({
+        "message": input
+    })
+    .to_string();
+
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(verify_url)
+        .header("Content-Type", "application/json")
+        .body(body)?;
+
+    dbg!(&request);
+
+    let response = client.request(request).await?;
+    dbg!(&response);
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response_to_string(response).await?;
+
+    assert_eq!(body, "Hello, world!");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test() {
+    let input = create_didcomm_message_scenario().await.unwrap();
+    verify_didcomm_message_scenario(input).await.unwrap();
+}

--- a/src/controllers/public/mod.rs
+++ b/src/controllers/public/mod.rs
@@ -1,5 +1,7 @@
+pub mod nodex_create_didcomm_message;
 pub mod nodex_create_identifier;
 pub mod nodex_create_verifiable_message;
 pub mod nodex_find_identifier;
 pub mod nodex_receive;
+pub mod nodex_verify_didcomm_message;
 pub mod nodex_verify_verifiable_message;

--- a/src/controllers/public/nodex_create_didcomm_message.rs
+++ b/src/controllers/public/nodex_create_didcomm_message.rs
@@ -1,0 +1,51 @@
+use actix_web::{web, HttpRequest, HttpResponse};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::{services::hub::Hub, usecase::didcomm_message_usecase::DidcommMessageUseCase};
+use crate::{
+    services::{
+        internal::{did_vc::DIDVCService, didcomm_encrypted::DIDCommEncryptedService},
+        nodex::NodeX,
+        project_verifier::ProjectVerifierImplOnNetworkConfig,
+    },
+    usecase::didcomm_message_usecase::GenerateDidcommMessageUseCaseError,
+};
+
+// NOTE: POST /create-didcomm-message
+#[derive(Deserialize, Serialize)]
+pub struct MessageContainer {
+    destination_did: String,
+    message: String,
+    operation_tag: String,
+}
+
+pub async fn handler(
+    _req: HttpRequest,
+    web::Json(json): web::Json<MessageContainer>,
+) -> actix_web::Result<HttpResponse> {
+    let now = Utc::now();
+
+    let usecase = DidcommMessageUseCase::new(
+        ProjectVerifierImplOnNetworkConfig::new(),
+        Hub::new(),
+        DIDCommEncryptedService::new(NodeX::new(), DIDVCService::new(NodeX::new())),
+    );
+
+    match usecase
+        .generate(json.destination_did, json.message, json.operation_tag, now)
+        .await
+    {
+        Ok(v) => Ok(HttpResponse::Ok().body(v)),
+        Err(e) => match e {
+            GenerateDidcommMessageUseCaseError::TargetDidNotFound(target) => {
+                log::warn!("Target DID not found. did = {}", target);
+                Ok(HttpResponse::NotFound().finish())
+            }
+            GenerateDidcommMessageUseCaseError::Other(e) => {
+                log::error!("{:?}", e);
+                Ok(HttpResponse::InternalServerError().finish())
+            }
+        },
+    }
+}

--- a/src/controllers/public/nodex_verify_didcomm_message.rs
+++ b/src/controllers/public/nodex_verify_didcomm_message.rs
@@ -1,0 +1,52 @@
+use actix_web::{web, HttpRequest, HttpResponse};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    services::{hub::Hub, internal::didcomm_encrypted::DIDCommEncryptedService},
+    usecase::{
+        didcomm_message_usecase::{DidcommMessageUseCase, VerifyDidcommMessageUseCaseError},
+    },
+};
+use crate::{
+    services::{
+        internal::did_vc::DIDVCService, nodex::NodeX,
+        project_verifier::ProjectVerifierImplOnNetworkConfig,
+    },
+};
+
+// NOTE: POST /verify-verifiable-message
+#[derive(Deserialize, Serialize)]
+pub struct MessageContainer {
+    message: String,
+}
+
+pub async fn handler(
+    _req: HttpRequest,
+    web::Json(json): web::Json<MessageContainer>,
+) -> actix_web::Result<HttpResponse> {
+    let now = Utc::now();
+
+    let usecase = DidcommMessageUseCase::new(
+        ProjectVerifierImplOnNetworkConfig::new(),
+        Hub::new(),
+        DIDCommEncryptedService::new(NodeX::new(), DIDVCService::new(NodeX::new())),
+    );
+
+    match usecase.verify(&json.message, now).await {
+        Ok(v) => Ok(HttpResponse::Ok().body(v)),
+        Err(e) => match e {
+            VerifyDidcommMessageUseCaseError::VerificationFailed => {
+                Ok(HttpResponse::Unauthorized().finish())
+            }
+            VerifyDidcommMessageUseCaseError::TargetDidNotFound(target) => {
+                log::warn!("Target DID not found. did = {}", target);
+                Ok(HttpResponse::NotFound().finish())
+            }
+            VerifyDidcommMessageUseCaseError::Other(e) => {
+                log::error!("{:?}", e);
+                Ok(HttpResponse::InternalServerError().finish())
+            }
+        },
+    }
+}

--- a/src/controllers/public/nodex_verify_didcomm_message.rs
+++ b/src/controllers/public/nodex_verify_didcomm_message.rs
@@ -2,17 +2,13 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    services::{hub::Hub, internal::didcomm_encrypted::DIDCommEncryptedService},
-    usecase::{
-        didcomm_message_usecase::{DidcommMessageUseCase, VerifyDidcommMessageUseCaseError},
-    },
+use crate::services::{
+    internal::did_vc::DIDVCService, nodex::NodeX,
+    project_verifier::ProjectVerifierImplOnNetworkConfig,
 };
 use crate::{
-    services::{
-        internal::did_vc::DIDVCService, nodex::NodeX,
-        project_verifier::ProjectVerifierImplOnNetworkConfig,
-    },
+    services::{hub::Hub, internal::didcomm_encrypted::DIDCommEncryptedService},
+    usecase::didcomm_message_usecase::{DidcommMessageUseCase, VerifyDidcommMessageUseCaseError},
 };
 
 // NOTE: POST /verify-verifiable-message

--- a/src/server.rs
+++ b/src/server.rs
@@ -35,6 +35,14 @@ pub fn new_server(sock_path: &PathBuf, sender: Box<dyn TransferClient>) -> Serve
                 "/verify-verifiable-message",
                 web::post().to(controllers::public::nodex_verify_verifiable_message::handler),
             )
+            .route(
+                "/create-didcomm-message",
+                web::post().to(controllers::public::nodex_create_didcomm_message::handler),
+            )
+            .route(
+                "/verify-didcomm-message",
+                web::post().to(controllers::public::nodex_verify_didcomm_message::handler),
+            )
             // NOTE: Internal (Private) Routes
             .service(
                 web::scope("/internal")

--- a/src/services/internal/didcomm_encrypted.rs
+++ b/src/services/internal/didcomm_encrypted.rs
@@ -108,7 +108,6 @@ impl DIDCommEncryptedService {
             .to(&[to_did])
             .body(&body)
             .map_err(|e| anyhow::anyhow!("Failed to initialize message with error = {:?}", e))?;
-        dbg!(&message);
 
         // NOTE: Has attachment
         if let Some(value) = metadata {

--- a/src/usecase/didcomm_message_usecase.rs
+++ b/src/usecase/didcomm_message_usecase.rs
@@ -21,7 +21,6 @@ pub struct DidcommMessageUseCase {
 }
 
 impl DidcommMessageUseCase {
-    #[allow(dead_code)]
     pub fn new<
         V: ProjectVerifier + Send + Sync + 'static,
         R: MessageActivityRepository + Send + Sync + 'static,
@@ -57,7 +56,6 @@ pub enum VerifyDidcommMessageUseCaseError {
 }
 
 impl DidcommMessageUseCase {
-    #[allow(dead_code)]
     pub async fn generate(
         &self,
         destination_did: String,
@@ -104,7 +102,6 @@ impl DidcommMessageUseCase {
         Ok(result)
     }
 
-    #[allow(dead_code)]
     pub async fn verify(
         &self,
         message: &str,


### PR DESCRIPTION
## Description

Implement apis `create_didcomm_message` and `verify_didcomm_message`.

## Check

- [x] e2e
- [x] Verify check with curl
You can check with following command.

```
curl --unix-socket ~/.nodex/run/nodex.sock \
-X POST \
-H "Content-Type: application/json" \
-d '{"destination_did" : "did:nodex:test:your-own-did" , "operation_tag": "didcomm", "message" : "test"}' \
http://localhost/create-didcomm-message

curl -v --unix-socket ~/.nodex/run/nodex.sock \
-X POST \
-H "Content-Type: application/json" \
-d '{"message": "received from create api" }' \
http://localhost/verify-didcomm-message
```

Here is my result.
```
MESSAGE=$(curl --unix-socket ~/.nodex/run/nodex.sock \
-X POST \
-H "Content-Type: application/json" \
-d '{"destination_did" : "did:nodex:test:EiDEp_0NuvczSI9n-8B5NmQoBQX__QORK-uZOhRs2zc_6A" , "operation_tag": "didcomm", "message" : "test"}' \
http://localhost/create-didcomm-message)

echo $MESSAGE | jaq .
{
  "ciphertext": "lnjEfAs1kX_VK8n1Io0H6Ntsm1vHFtI_hrsY4OSOQhBee7Q87lajCkZCxmi7QrL_V9IZ7Lt9Uj4SEN4U9YxcoH3jLczmhccU1xqoYWmLn0s4dbq_CGkfnx8toHAgsCGqk6gLr-6gMvqE6urMA55MO0VBRQXYzZdh10jenIJKs8Z9Jlj-CrrgdYzeaodADIXlE1rtKWXpIpUKKmPOQ6_mUXXha6Jhrn9qsRsX623fd2Jb_z_6txB1rEH36KezI50-iil1amhjNsb4PtPIlemS2-zRnKdjRzn9Uljtky9H9n0XxODuZse6x0VYRbW1xhCIwGXyKtJo6ZsA1R00NUmbiLy8lXNNgCeS1KAr6NfDrkZ1_ByEYGQ_hcotLxlZm3sN0-OBORXXf05H8utPSDgzhFZFYiCdWael4ovLr8gtFiaXUCTZBc0aHqDbTsIL3xX2lMZ6aE5NgP2zDMfT1IDnwGjJicUv5xacdaXXxmPTLfFuh318BiJgYwiCWqQKCJrLD6Ko5q66YeMW1edZf1I8EHvopb47Q81Kx4FxFmqV5X1XVIUDCLtNBqmxmbL20M4ahZfBU4AtJKoB4quWZmnE12wnEwsg2VNz5NIBagig34wDzQmQRuwP_2phndJkb7TiZCq7B6oSa9xXqlOG39bRWb1c2aKDqZ8_qgcYpc8l9CY6lyf9cWPiAxzQ0QhgIBBC6r4DZ3hfc831P8JYetlNSd-cgWOxC47U8djDEUXTN-Gf7LHIab2dgRdrFHXBXOdVsWsJovV11Wf9e-Bvb4VBhm-8wOGy16JAGNwGwBK2KGQqzAfitiwj5w4Cb2KXU12ynRELG85ie4SrSsxnGTuU3Z5nDyvxabzFpK_U4_Mz0e6IyZG5aMPew5S0ivu00trJgD0ARwLpcYHCEcVLLpXhcmu2stn3Mh-rqonx2bTJjD1o-vQFAFQy4jV5L5p-XKMyx-HVacBEZYnsPQZvRKe1xIsJhbadamhJ3ZOxgPAWY5-SPLskDl7QdaCE68rnBry9x4T7xO3ix0b8NjKKYwqSfv4WtPoP-p96eWt8ieuut5NLhpDHj_w_9jPVBpHItiGg5i5a5dOUM8VdE6Jky46_Mogt2DrLogOlIhiVQvOYaTYlvFpDrClpK7Oee2Pf02gnrLV3N_bE-kBXl95fnKgFC7uNUGBf1E7EB5yg_XP4pJ2VUtCjTBd8pmvFzyva8nkDNcMZo5na_n3OXXY_4mVFRvVOZcMo8Ke1cU7dXwM-Q7n9NPVIUDEgYeMy4R8RQ1LpNOso1r8rTyX5-2c7ol6Qo23zNWlU3HgFSEE0IIa1XqR9iF096qe6xnbjV6JbHRkaXridVpfhDKUMrpb6n8uIN1rtFGkYoNWvegAClCJTDaZolIgszp4LaQLy2kXHWqsEmcinvmNiyEQPz0ID2Z_IQdoN345PJkQT5o6yqvQBaj5n5Gx_skv1TOeRVsRGS01QE5MFe5vw-GRU6dtYKavD2m7vVzTjcIsONdqrYKZqUYT6f34Pom3vNH0pWnYGPSeEyULCMoF0n-GM-I0deCvCKM5y3edFU-QNtxHB0Kt2XKrkEQ8_QEy1B6ahC0OZEQcb2w-tQDDgqg8At2SlywSwBUAzJD5DDsHsHxpS9xBoQRs_nuiE0iaJatL_AsJJWSQ4DWmOC1RD1PCQ_yj5Pzyk8Mrpx0HQEa7T0fdQELiRIQMNSJeCO3-RxFvpDRgwFTxStRiIS2ZLSfCod5p30dDqdiclnr65IT6Jhghx0CdtctYSkRVwgx25xUqtJjJkLv68r5yl3ZsOilvIIQzJ6attbAU0vK4NPkDn21wTjWVgX-TmoQezQXZyvP6vqACppJU3LFoY7srrDHJ0d-m0PbODBvoTffNZWq5EF2vbwR4qs1P-w8EpIv9MSDClU4O5kl0YOsAdT5bEngLkDgIMFoOzZ3Mf1Ux4lQ-FQVyBmbagndYV5qmbdp31KUlt7k8cfAICZRvR6mfZxldTWipYeZ_MH8rty6j3t5r4jjk5vM8IqMrq5oIM7rY5s4UXjKhtqume3BdjqLnh0DAk6-tMr0_MH2J3EtITjvIoTXwbdhDuyAEpdc0FkTjWuxleqFX2xQq2nC1q2lrAIVRZoue4d6OpkZJqoL69Eot7g1QgxXzNaNXxbYr2IwMtNgVrkhxyWnTyAxc3j63gZVUq8MqQqIefuwN6FDUI_dNRRKWiRgnUwv1dcIEwAT6UMDi5lq8flSZ2dbodD4_kqvbCrBLXVfmCyh6HspSmLgidl-h0ComF-e0SATB2WsDqOJDLzYCJRWYC2yn23kIReCj28Gc97YOs9iECLNZqQw1hhJPiEnHlLT6Ha4cr2QpcxnLuK7eSu4z3UAitcEfKlLbjWzRthTINYHO9jCrK84dmliSNvlfAItxwCMnEt80qthBDOr8-35ccSg5HUHo_hjmkJ_YmDaFP-clsw0RVFuSipU2l1qNKqfavS0YbEhhL6-X4FmKKZNYpkpSmVEryeVpRHd3jz4o_GrntDT1lPc6Rl9LrdS3eBV5LIdOeGDYlauC-ZEf-ESQj3k7LxoYm2UQ1LUBdmof2Qgm_zNJmdeR03q5hMfiRm_0x6wD-8sCmSk77Qbjq4W9TFxUa_IZ823_F2EFIr_tNT6xODLIM3WyU_09Ka7rj-68VlVnE9g0Xi5XWDx50AACLt62mWojYJ_n_oPRjpfJNv6aZk9j1z_byENWpIUFx2pDxQwQt81kDAHFJ7OShXuCTvTvAfIYhmAHcSEAmyVo4tVLjJen439PiJDMc-rzAvun9Et1GObMCVUqJkFdmo_y_oy2wbeCnmT_qw4UJiG3bqDwgYGmZTf_dGG409OLvk7yCb9Uo699JYAS2WlU-d6EuN3agkUZKMtdQ8tHkxWrih2N76sJMQi-o5mKcQLsmmY-9gX9HgzfAbWzDl1ubgfsqox2Aer1gFQr_YfaIb3AJdz3qLtrKuuBmodM8h8zd0rsgPUOmfWoBnX9qQjXftwMrtATH8H2gmK6p4qFxktp6_ehxmN6MI1Wd1ApHrdO3uWkgCFaW3ebcSKhnDbqMMQRmRegyYcY7Z0WzuOKSz_2d_RQBR41D9ovMqlwqWRxw3JTvoaA4cgGSuvvxGtTxu4RehoPN3PRv13UbtAxGdqMRvPqNAmzOWKy-HRIBE96TtoaCREtwQgBveLN1rUnOiEH3BD_eQ9Aq9dXtCHtDDkAEedNEB7a3KRQ2f0L49-YRVV0KOWlctg53qhvFTgG0z7aRdmRCgfIVjK09xfQo3BGQilYDHgwImeYl8DpoyQn5xND6eaxfZ5Z5wuE3tPsrzCRjf3eF2a4",
  "iv": "MnYTxpDMqkwNl6cr6pu8FlFsZFyQvaWv",
  "protected": "eyJ0eXAiOiJhcHBsaWNhdGlvbi9kaWRjb21tLWVuY3J5cHRlZCtqc29uIiwiZW5jIjoiWEMyMFAiLCJraWQiOiJfbVZZOS15RXhoNHhFRVF2MF82MDFYeTR6aU1HdkR3UlN6S3ByWTdmX3lZIiwic2tpZCI6ImRpZDpub2RleDp0ZXN0OkVpREVwXzBOdXZjelNJOW4tOEI1Tm1Rb0JRWF9fUU9SSy11Wk9oUnMyemNfNkEiLCJhbGciOiJFQ0RILTFQVStYQzIwUEtXIn0",
  "recipients": [
    {
      "encrypted_key": "4-KVOg8I8tZ4qmR0tXzOGuMIZ54GiqV9TWnj42xMCeI",
      "header": {
        "alg": "ECDH-1PU+XC20PKW",
        "epk": {
          "crv": "X25519",
          "kty": "OKP",
          "x": "o4nPbnnijaefHEIGSOLfaP9efXPozdP6kPTWiGCw1Bc"
        },
        "iv": "_4Yv7jJqkLZ-zWimFupaGHoLDDtoMU28",
        "key_ops": [],
        "kid": "did:nodex:test:EiDEp_0NuvczSI9n-8B5NmQoBQX__QORK-uZOhRs2zc_6A",
        "tag": "d-qN26-08cv2gIUSA6pi8Q"
      }
    }
  ],
  "tag": "3hotac4E4K0lTzCLYTFK_w"
}

BODY=$(jaq -n --arg message $MESSAGE '$ARGS.named')

curl -v --unix-socket ~/.nodex/run/nodex.sock \
-X POST \
-H "Content-Type: application/json" \
-d  $BODY \
http://localhost/verify-didcomm-message
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying /Users/rabe1028/.nodex/run/nodex.sock:0...
* Connected to localhost (/Users/rabe1028/.nodex/run/nodex.sock) port 80
> POST /verify-didcomm-message HTTP/1.1
> Host: localhost
> User-Agent: curl/8.4.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 4142
> 
< HTTP/1.1 200 OK
< content-length: 4
< x-version: 0.1.0
< date: Mon, 26 Feb 2024 05:26:49 GMT
< 
* Connection #0 to host localhost left intact
test%
```