### PR TITLE
chore: specify `target_commitish` when create a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: "v${{ steps.set_crate_version.outputs.version }}",
+              target_commitish: "v1",
               generate_release_notes: true
             });
             return release.data.id;


### PR DESCRIPTION
## Description

Release Assets Release Body and zipped code were created from the main branch.
https://github.com/nodecross/nodex/releases/tag/v1.2.6

This is because the `target_commitish` argument was not specified when calling the github api.

