### PR TITLE
chore: fix CI jobs on MacOS

### DIFF
--- a/.github/workflows/default-pipeline.yml
+++ b/.github/workflows/default-pipeline.yml
@@ -92,13 +92,17 @@ jobs:
     steps:
       - name: (checkout) source code
         uses: actions/checkout@v4
+      
+      # https://github.com/Homebrew/homebrew-core/issues/165793
+      # github actions overwrites brew's python. Force it to reassert itself, by running in a separate step.
+      - name: unbreak python in github actions
+        run: |
+          find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete
+          sudo rm -rf /Library/Frameworks/Python.framework/
+          brew install --force python3 && brew unlink python3 && brew unlink python3 && brew link --overwrite python3
 
       - name: Setup docker and docker-compose (missing on MacOS)
         run: |
-          # https://github.com/Homebrew/homebrew-core/issues/165793
-          # Workaround GitHub Actions Python issues
-          brew unlink python && brew link --overwrite python
-
           brew install docker docker-compose colima
 
           # Link the Docker Compose v2 plugin so it's understood by the docker CLI

--- a/.github/workflows/default-pipeline.yml
+++ b/.github/workflows/default-pipeline.yml
@@ -80,7 +80,7 @@ jobs:
 
   e2e-macos:
     needs: build-macos
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/default-pipeline.yml
+++ b/.github/workflows/default-pipeline.yml
@@ -101,6 +101,8 @@ jobs:
           mkdir -p ~/.docker/cli-plugins
           ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
 
+          colima start
+
       - name: (run) download artifacts (macos)
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/default-pipeline.yml
+++ b/.github/workflows/default-pipeline.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Setup docker and docker-compose (missing on MacOS)
         run: |
-          brew install docker docker-compose
+          brew install docker docker-compose colima
 
           # Link the Docker Compose v2 plugin so it's understood by the docker CLI
           mkdir -p ~/.docker/cli-plugins

--- a/.github/workflows/default-pipeline.yml
+++ b/.github/workflows/default-pipeline.yml
@@ -94,17 +94,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup docker and docker-compose (missing on MacOS)
-        # ref: https://github.com/actions/runner/issues/1456
         run: |
-          # colima doesn't exist on MacOS 13 runner. So we need to install it manually
-          # https://github.com/actions/runner-images/issues/6216
-          brew install docker docker-compose colima
+          brew install docker docker-compose
 
           # Link the Docker Compose v2 plugin so it's understood by the docker CLI
           mkdir -p ~/.docker/cli-plugins
           ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
-
-          colima start
 
       - name: (run) download artifacts (macos)
         uses: actions/download-artifact@v4

--- a/.github/workflows/default-pipeline.yml
+++ b/.github/workflows/default-pipeline.yml
@@ -95,6 +95,10 @@ jobs:
 
       - name: Setup docker and docker-compose (missing on MacOS)
         run: |
+          # https://github.com/Homebrew/homebrew-core/issues/165793
+          # Workaround GitHub Actions Python issues
+          brew unlink python && brew link --overwrite python
+
           brew install docker docker-compose colima
 
           # Link the Docker Compose v2 plugin so it's understood by the docker CLI

--- a/.github/workflows/default-pipeline.yml
+++ b/.github/workflows/default-pipeline.yml
@@ -102,6 +102,9 @@ jobs:
           ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
 
           colima start
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
 
       - name: (run) download artifacts (macos)
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Description

- https://github.com/actions/runner/issues/1456 was resolved.
- The job `e2e-macos` is too heavy, so I increased that timeout minutes.