### PR TITLE
fix: change verify response type to VC

### DIFF
--- a/e2e/tests/test_didcomm_message.rs
+++ b/e2e/tests/test_didcomm_message.rs
@@ -85,8 +85,14 @@ async fn verify_didcomm_message_scenario(input: String) -> anyhow::Result<()> {
     assert_eq!(response.status(), StatusCode::OK);
 
     let body = response_to_string(response).await?;
+    let body_json = serde_json::from_str::<serde_json::Value>(&body)?;
 
-    assert_eq!(body, "Hello, world!");
+    assert_eq!(
+        body_json["credentialSubject"]["container"]["payload"]
+            .as_str()
+            .unwrap(),
+        "Hello, world!"
+    );
 
     Ok(())
 }

--- a/e2e/tests/test_verifiable_message.rs
+++ b/e2e/tests/test_verifiable_message.rs
@@ -90,8 +90,14 @@ async fn verify_verifiable_message_scenario(input: String) -> anyhow::Result<()>
     assert_eq!(response.status(), StatusCode::OK);
 
     let body = response_to_string(response).await?;
+    let body_json = serde_json::from_str::<serde_json::Value>(&body)?;
 
-    assert_eq!(body, "Hello, world!");
+    assert_eq!(
+        body_json["credentialSubject"]["container"]["payload"]
+            .as_str()
+            .unwrap(),
+        "Hello, world!"
+    );
 
     Ok(())
 }

--- a/src/controllers/public/nodex_verify_didcomm_message.rs
+++ b/src/controllers/public/nodex_verify_didcomm_message.rs
@@ -30,7 +30,7 @@ pub async fn handler(
     );
 
     match usecase.verify(&json.message, now).await {
-        Ok(v) => Ok(HttpResponse::Ok().body(v)),
+        Ok(v) => Ok(HttpResponse::Ok().json(v)),
         Err(e) => match e {
             VerifyDidcommMessageUseCaseError::VerificationFailed => {
                 Ok(HttpResponse::Unauthorized().finish())

--- a/src/controllers/public/nodex_verify_verifiable_message.rs
+++ b/src/controllers/public/nodex_verify_verifiable_message.rs
@@ -31,7 +31,7 @@ pub async fn handler(
     );
 
     match usecase.verify(&json.message, now).await {
-        Ok(v) => Ok(HttpResponse::Ok().body(v)),
+        Ok(v) => Ok(HttpResponse::Ok().json(v)),
         Err(e) => match e {
             VerifyVerifiableMessageUseCaseError::VerificationFailed => {
                 Ok(HttpResponse::Unauthorized().finish())

--- a/src/usecase/didcomm_message_usecase.rs
+++ b/src/usecase/didcomm_message_usecase.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::{
+    nodex::schema::general::GeneralVcDataModel,
     repository::message_activity_repository::{
         CreatedMessageActivityRequest, MessageActivityRepository, VerifiedMessageActivityRequest,
         VerifiedStatus,
@@ -106,7 +107,7 @@ impl DidcommMessageUseCase {
         &self,
         message: &str,
         now: DateTime<Utc>,
-    ) -> Result<String, VerifyDidcommMessageUseCaseError> {
+    ) -> Result<GeneralVcDataModel, VerifyDidcommMessageUseCaseError> {
         let message = serde_json::from_str::<Value>(message).context("failed to decode str")?;
         let verified = self
             .didcomm_encrypted_service
@@ -128,7 +129,7 @@ impl DidcommMessageUseCase {
         // check in verified. maybe exists?
         let my_did = super::get_my_did();
 
-        let container = verified.credential_subject.container;
+        let container = verified.clone().credential_subject.container;
 
         let message = serde_json::from_value::<EncodedMessage>(container)
             .context("failed to deserialize to EncodedMessage")?;
@@ -147,7 +148,7 @@ impl DidcommMessageUseCase {
                 })
                 .await
                 .context("failed to add verify activity")?;
-            Ok(message.payload)
+            Ok(verified)
         } else {
             self.message_activity_repository
                 .add_verify_activity(VerifiedMessageActivityRequest {

--- a/src/usecase/didcomm_message_usecase.rs
+++ b/src/usecase/didcomm_message_usecase.rs
@@ -188,6 +188,7 @@ mod tests {
             didcomm_message_usecase::DidcommMessageUseCase, verifiable_message_usecase::tests::*,
         },
     };
+    use serde_json;
 
     #[tokio::test]
     async fn test_create_and_verify() {
@@ -220,7 +221,10 @@ mod tests {
             .unwrap();
 
         let verified = usecase.verify(&generated, Utc::now()).await.unwrap();
-        assert_eq!(verified, message);
+        let encoded_message =
+            serde_json::from_value::<EncodedMessage>(verified.credential_subject.container)
+                .unwrap();
+        assert_eq!(encoded_message.payload, message);
     }
 
     mod generate_failed {

--- a/src/usecase/verifiable_message_usecase.rs
+++ b/src/usecase/verifiable_message_usecase.rs
@@ -106,18 +106,17 @@ impl VerifiableMessageUseCase {
         &self,
         message: &str,
         now: DateTime<Utc>,
-    ) -> Result<String, VerifyVerifiableMessageUseCaseError> {
-        let message =
+    ) -> Result<GeneralVcDataModel, VerifyVerifiableMessageUseCaseError> {
+        let vc =
             serde_json::from_str::<GeneralVcDataModel>(message).context("failed to decode str")?;
-        let from_did = message.issuer.id.clone();
+        let from_did = vc.issuer.id.clone();
 
         // TODO: return GeneralVCDataModel
-        let _ = DIDVCService::verify(&self.vc_service, message.clone())
+        let _ = DIDVCService::verify(&self.vc_service, vc.clone())
             .await
             .context("verify failed")?;
-        let vc = message;
 
-        let container = vc.credential_subject.container;
+        let container = vc.clone().credential_subject.container;
 
         let message = serde_json::from_value::<EncodedMessage>(container)
             .context("failed to deserialize to EncodedMessage")?;
@@ -142,7 +141,7 @@ impl VerifiableMessageUseCase {
                 })
                 .await
                 .context("failed to add verify activity")?;
-            Ok(message.payload)
+            Ok(vc)
         } else {
             self.message_activity_repository
                 .add_verify_activity(VerifiedMessageActivityRequest {

--- a/src/usecase/verifiable_message_usecase.rs
+++ b/src/usecase/verifiable_message_usecase.rs
@@ -308,7 +308,10 @@ pub mod tests {
         );
 
         let verified = usecase.verify(&generated, Utc::now()).await.unwrap();
-        assert_eq!(verified, message);
+        let encoded_message =
+            serde_json::from_value::<EncodedMessage>(verified.credential_subject.container)
+                .unwrap();
+        assert_eq!(encoded_message.payload, message);
     }
 
     mod generate_failed {


### PR DESCRIPTION
When DIDComm message verify, user application cannot know VC, so verify result should be VC.
When verifying VC, the result is also adjusted to DIDComm.

<details>
<summary> result of verify_didcomm_message.py </summary>

```
{
    "issuer": {
        "id": "$DID"
    },
    "issuanceDate": "2024-03-17T06:31:47.335224+00:00",
    "@context": [
        "https://www.w3.org/2018/credentials/v1"
    ],
    "type": [
        "VerifiableCredential"
    ],
    "credentialSubject": {
        "container": {
            "created_at": "2024-03-17T06:31:47.335224+00:00",
            "message_id": "5a6a2d89-7b19-4be7-9787-5c099929d8de",
            "payload": "{\"string\": \"value\",\"number\": 1,\"boolean\": true,\"array\": [],\"map\": {}}",
            "project_hmac": ""
        }
    },
    "proof": {
        "type": "EcdsaSecp256k1Signature2019",
        "proofPurpose": "authentication",
        "created": "2024-03-17T06:31:47.364811+00:00",
        "verificationMethod": "",
        "jws": "",
        "controller": null,
        "challenge": null,
        "domain": null
    }
}
```
</details>


<details>
<summary> result of verify_vc_message.py </summary>

```
{
    "issuer": {
        "id": "$DID"
    },
    "issuanceDate": "2024-03-17T06:39:29.096958+00:00",
    "@context": [
        "https://www.w3.org/2018/credentials/v1"
    ],
    "type": [
        "VerifiableCredential"
    ],
    "credentialSubject": {
        "container": {
            "created_at": "2024-03-17T06:39:29.096958+00:00",
            "destination_did": "$DID",
            "message_id": "f32cd672-a27e-457f-bd11-f7d25fd95b9b",
            "payload": "{\"string\": \"value\",\"number\": 1,\"boolean\": True,\"array\": [],\"map\": {}}",
            "project_hmac": ""
        }
    },
    "proof": {
        "type": "EcdsaSecp256k1Signature2019",
        "proofPurpose": "authentication",
        "created": "2024-03-17T06:39:29.225881+00:00",
        "verificationMethod": "",
        "jws": "",
        "controller": null,
        "challenge": null,
        "domain": null
    }
}
```

</details>