### PR TITLE
Add HTTP error handling of message activity endpoint

### DIFF
--- a/src/controllers/public/nodex_create_didcomm_message.rs
+++ b/src/controllers/public/nodex_create_didcomm_message.rs
@@ -42,6 +42,26 @@ pub async fn handler(
                 log::warn!("Target DID not found. did = {}", target);
                 Ok(HttpResponse::NotFound().finish())
             }
+            GenerateDidcommMessageUseCaseError::BadRequest(message) => {
+                log::warn!("Bad Request: {}", message);
+                Ok(HttpResponse::BadRequest().body(message))
+            }
+            GenerateDidcommMessageUseCaseError::Unauthorized(message) => {
+                log::warn!("Unauthorized: {}", message);
+                Ok(HttpResponse::Unauthorized().body(message))
+            }
+            GenerateDidcommMessageUseCaseError::Forbidden(message) => {
+                log::warn!("Forbidden: {}", message);
+                Ok(HttpResponse::Forbidden().body(message))
+            }
+            GenerateDidcommMessageUseCaseError::NotFound(message) => {
+                log::warn!("Not Found: {}", message);
+                Ok(HttpResponse::NotFound().body(message))
+            }
+            GenerateDidcommMessageUseCaseError::Conflict(message) => {
+                log::warn!("Conflict: {}", message);
+                Ok(HttpResponse::Conflict().body(message))
+            }
             GenerateDidcommMessageUseCaseError::Other(e) => {
                 log::error!("{:?}", e);
                 Ok(HttpResponse::InternalServerError().finish())

--- a/src/controllers/public/nodex_verify_didcomm_message.rs
+++ b/src/controllers/public/nodex_verify_didcomm_message.rs
@@ -39,6 +39,26 @@ pub async fn handler(
                 log::warn!("Target DID not found. did = {}", target);
                 Ok(HttpResponse::NotFound().finish())
             }
+            VerifyDidcommMessageUseCaseError::BadRequest(message) => {
+                log::warn!("Bad Request: {}", message);
+                Ok(HttpResponse::BadRequest().body(message))
+            }
+            VerifyDidcommMessageUseCaseError::Unauthorized(message) => {
+                log::warn!("Unauthorized: {}", message);
+                Ok(HttpResponse::Unauthorized().body(message))
+            }
+            VerifyDidcommMessageUseCaseError::Forbidden(message) => {
+                log::warn!("Forbidden: {}", message);
+                Ok(HttpResponse::Forbidden().body(message))
+            }
+            VerifyDidcommMessageUseCaseError::NotFound(message) => {
+                log::warn!("Not Found: {}", message);
+                Ok(HttpResponse::NotFound().body(message))
+            }
+            VerifyDidcommMessageUseCaseError::Conflict(message) => {
+                log::warn!("Conflict: {}", message);
+                Ok(HttpResponse::Conflict().body(message))
+            }
             VerifyDidcommMessageUseCaseError::Other(e) => {
                 log::error!("{:?}", e);
                 Ok(HttpResponse::InternalServerError().finish())

--- a/src/repository/message_activity_repository.rs
+++ b/src/repository/message_activity_repository.rs
@@ -55,5 +55,5 @@ pub trait MessageActivityRepository {
     async fn add_verify_activity(
         &self,
         request: VerifiedMessageActivityRequest,
-    ) -> anyhow::Result<()>;
+    ) -> Result<(), MessageActivityHttpError>;
 }

--- a/src/repository/message_activity_repository.rs
+++ b/src/repository/message_activity_repository.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use thiserror::Error;
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Serialize)]
@@ -27,12 +28,30 @@ pub enum VerifiedStatus {
     Invalid,
 }
 
+#[derive(Error, Debug)]
+pub enum MessageActivityHttpError {
+    #[error("Bad Request: {0}")]
+    BadRequest(String),
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
+    #[error("Forbidden: {0}")]
+    Forbidden(String),
+    #[error("Not Found: {0}")]
+    NotFound(String),
+    #[error("Conflict: {0}")]
+    Conflict(String),
+    #[error("Internal Server Error: {0}")]
+    InternalServerError(String),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
 #[async_trait::async_trait]
 pub trait MessageActivityRepository {
     async fn add_create_activity(
         &self,
         request: CreatedMessageActivityRequest,
-    ) -> anyhow::Result<()>;
+    ) -> Result<(), MessageActivityHttpError>;
     async fn add_verify_activity(
         &self,
         request: VerifiedMessageActivityRequest,

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -1,3 +1,4 @@
+use crate::repository::message_activity_repository::MessageActivityHttpError;
 use crate::server_config;
 use crate::{
     nodex::utils::hub_client::{HubClient, HubClientConfig},
@@ -9,7 +10,7 @@ use crate::{
 use anyhow::Context;
 
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 
 use super::{
     internal::{did_vc::DIDVCService, didcomm_encrypted::DIDCommEncryptedService},
@@ -209,7 +210,7 @@ impl MessageActivityRepository for Hub {
     async fn add_create_activity(
         &self,
         request: CreatedMessageActivityRequest,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), MessageActivityHttpError> {
         // TODO: refactoring more simple
         let service = DIDCommEncryptedService::new(NodeX::new(), DIDVCService::new(NodeX::new()));
 
@@ -220,7 +221,8 @@ impl MessageActivityRepository for Hub {
         };
         let payload = service
             .generate(&project_did, &json!(request), None, request.occurred_at)
-            .await?;
+            .await
+            .context("failed to generate payload")?;
         let payload = serde_json::to_string(&payload).context("failed to serialize")?;
 
         let res = self
@@ -228,20 +230,30 @@ impl MessageActivityRepository for Hub {
             .post("/v1/message_activity", &payload)
             .await?;
 
-        match res.status() {
-            reqwest::StatusCode::OK => {
-                res.json::<EmptyResponse>().await?;
-                Ok(())
+        let status = res.status();
+        let json: Value = res.json().await.context("Failed to read response body")?;
+        let message = if let Some(message) = json.get("message").map(|v| v.to_string()) {
+            message
+        } else {
+            "".to_string()
+        };
+
+        match status {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::BAD_REQUEST => Err(MessageActivityHttpError::BadRequest(message)),
+            reqwest::StatusCode::UNAUTHORIZED => {
+                Err(MessageActivityHttpError::Unauthorized(message))
             }
-            reqwest::StatusCode::BAD_REQUEST => {
-                anyhow::bail!("StatusCode=400, bad request")
-            }
+            reqwest::StatusCode::FORBIDDEN => Err(MessageActivityHttpError::Forbidden(message)),
+            reqwest::StatusCode::NOT_FOUND => Err(MessageActivityHttpError::NotFound(message)),
+            reqwest::StatusCode::CONFLICT => Err(MessageActivityHttpError::Conflict(message)),
             reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
-                anyhow::bail!("StatusCode=500, internal server error");
+                Err(MessageActivityHttpError::InternalServerError(message))
             }
-            other => {
-                anyhow::bail!("StatusCode={other}, unexpected response");
-            }
+            other => Err(MessageActivityHttpError::Other(anyhow::anyhow!(
+                "StatusCode={}, unexpected response",
+                other
+            ))),
         }
     }
 

--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -260,7 +260,7 @@ impl MessageActivityRepository for Hub {
     async fn add_verify_activity(
         &self,
         request: VerifiedMessageActivityRequest,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), MessageActivityHttpError> {
         // TODO: refactoring more simple
         let service = DIDCommEncryptedService::new(NodeX::new(), DIDVCService::new(NodeX::new()));
         let project_did = {
@@ -270,7 +270,8 @@ impl MessageActivityRepository for Hub {
         };
         let payload = service
             .generate(&project_did, &json!(request), None, request.verified_at)
-            .await?;
+            .await
+            .context("failed to generate payload")?;
         let payload = serde_json::to_string(&payload).context("failed to serialize")?;
 
         let res = self
@@ -278,20 +279,30 @@ impl MessageActivityRepository for Hub {
             .put("/v1/message_activity", &payload)
             .await?;
 
-        match res.status() {
-            reqwest::StatusCode::OK => {
-                res.json::<EmptyResponse>().await?;
-                Ok(())
+        let status = res.status();
+        let json: Value = res.json().await.context("Failed to read response body")?;
+        let message = if let Some(message) = json.get("message").map(|v| v.to_string()) {
+            message
+        } else {
+            "".to_string()
+        };
+
+        match status {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::BAD_REQUEST => Err(MessageActivityHttpError::BadRequest(message)),
+            reqwest::StatusCode::UNAUTHORIZED => {
+                Err(MessageActivityHttpError::Unauthorized(message))
             }
-            reqwest::StatusCode::BAD_REQUEST => {
-                anyhow::bail!("StatusCode=400, bad request")
-            }
+            reqwest::StatusCode::FORBIDDEN => Err(MessageActivityHttpError::Forbidden(message)),
+            reqwest::StatusCode::NOT_FOUND => Err(MessageActivityHttpError::NotFound(message)),
+            reqwest::StatusCode::CONFLICT => Err(MessageActivityHttpError::Conflict(message)),
             reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
-                anyhow::bail!("StatusCode=500, internal server error");
+                Err(MessageActivityHttpError::InternalServerError(message))
             }
-            other => {
-                anyhow::bail!("StatusCode={other}, unexpected response");
-            }
+            other => Err(MessageActivityHttpError::Other(anyhow::anyhow!(
+                "StatusCode={}, unexpected response",
+                other
+            ))),
         }
     }
 }

--- a/src/usecase/didcomm_message_usecase.rs
+++ b/src/usecase/didcomm_message_usecase.rs
@@ -346,8 +346,10 @@ mod tests {
                 async fn add_create_activity(
                     &self,
                     _request: CreatedMessageActivityRequest,
-                ) -> anyhow::Result<()> {
-                    Err(anyhow::anyhow!("create activity failed"))
+                ) -> Result<(), MessageActivityHttpError> {
+                    Err(MessageActivityHttpError::Other(anyhow::anyhow!(
+                        "create activity failed"
+                    )))
                 }
 
                 async fn add_verify_activity(
@@ -461,7 +463,7 @@ mod tests {
                 async fn add_create_activity(
                     &self,
                     _request: CreatedMessageActivityRequest,
-                ) -> anyhow::Result<()> {
+                ) -> Result<(), MessageActivityHttpError> {
                     unreachable!()
                 }
 

--- a/src/usecase/verifiable_message_usecase.rs
+++ b/src/usecase/verifiable_message_usecase.rs
@@ -249,7 +249,7 @@ pub mod tests {
         async fn add_create_activity(
             &self,
             _request: CreatedMessageActivityRequest,
-        ) -> anyhow::Result<()> {
+        ) -> Result<(), MessageActivityHttpError> {
             Ok(())
         }
 
@@ -398,8 +398,10 @@ pub mod tests {
                 async fn add_create_activity(
                     &self,
                     _request: CreatedMessageActivityRequest,
-                ) -> anyhow::Result<()> {
-                    Err(anyhow::anyhow!("create activity failed"))
+                ) -> Result<(), MessageActivityHttpError> {
+                    Err(MessageActivityHttpError::BadRequest(
+                        "create activity failed".to_string(),
+                    ))
                 }
 
                 async fn add_verify_activity(
@@ -586,7 +588,7 @@ pub mod tests {
                 async fn add_create_activity(
                     &self,
                     _request: CreatedMessageActivityRequest,
-                ) -> anyhow::Result<()> {
+                ) -> Result<(), MessageActivityHttpError> {
                     unreachable!()
                 }
 

--- a/src/usecase/verifiable_message_usecase.rs
+++ b/src/usecase/verifiable_message_usecase.rs
@@ -256,7 +256,7 @@ pub mod tests {
         async fn add_verify_activity(
             &self,
             _request: VerifiedMessageActivityRequest,
-        ) -> anyhow::Result<()> {
+        ) -> Result<(), MessageActivityHttpError> {
             Ok(())
         }
     }
@@ -407,7 +407,7 @@ pub mod tests {
                 async fn add_verify_activity(
                     &self,
                     _request: VerifiedMessageActivityRequest,
-                ) -> anyhow::Result<()> {
+                ) -> Result<(), MessageActivityHttpError> {
                     unreachable!()
                 }
             }
@@ -595,8 +595,10 @@ pub mod tests {
                 async fn add_verify_activity(
                     &self,
                     _request: VerifiedMessageActivityRequest,
-                ) -> anyhow::Result<()> {
-                    Err(anyhow::anyhow!("verify activity failed"))
+                ) -> Result<(), MessageActivityHttpError> {
+                    Err(MessageActivityHttpError::Other(anyhow::anyhow!(
+                        "add verify activity failed"
+                    )))
                 }
             }
 


### PR DESCRIPTION
## Why
Difficult to troubleshoot due to lack of handling of HTTP errors in HUB.

## What
Add HTTP error handling of POST and PUT message activity.

## Check
Confirmed that python test code can catch error status and message.