### PR TITLE
/v1/message_activity -> /v1/message-activity

### DIFF
--- a/src/services/hub.rs
+++ b/src/services/hub.rs
@@ -225,7 +225,7 @@ impl MessageActivityRepository for Hub {
 
         let res = self
             .http_client
-            .post("/v1/message_activity", &payload)
+            .post("/v1/message-activity", &payload)
             .await?;
 
         match res.status() {
@@ -263,7 +263,7 @@ impl MessageActivityRepository for Hub {
 
         let res = self
             .http_client
-            .put("/v1/message_activity", &payload)
+            .put("/v1/message-activity", &payload)
             .await?;
 
         match res.status() {

--- a/test_resource/studio.yaml
+++ b/test_resource/studio.yaml
@@ -90,7 +90,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /v1/message_activity:
+  /v1/message-activity:
     post:
       summary: Send message activity
       operationId: sendMessageActivity


### PR DESCRIPTION
## What

Fix URL of the message activity endpoint.

`/v1/message_activity` -> `/v1/message-activity`

## Check
Teted at my local development environment, with fixed server app.