### PR TITLE
Refactor example codes of vc

### DIFF
--- a/examples/python/v2/cli/generate_vc_message.py
+++ b/examples/python/v2/cli/generate_vc_message.py
@@ -1,18 +1,37 @@
 from sock import post
+import json
+import pprint
+
+# PLEASE WRITE destination_did, message, AND operation_tag.
+destination_did = (
+    "did:nodex:test:DummyDummyDummyDummyDummyDummyDummyDummyDummyD"
+)
+message = {
+    "message": {
+        "string": "value",
+        "number": 1,
+        "boolean": True,
+        "array": ["foo", "bar", "baz"],
+        "map": {"key": "value"},
+    }
+}
+operation_tag = "test-operation-tag"
 
 
 def main():
-    # The endpoint and payload you want to send
-    endpoint = "/create-verifiable-message"
     payload = {
-        "destination_did": "did:nodex:test:EiBprXreMiba4loyl3psXm0RsECdtlCiQIjM8G9BtdQplA",
-        "message": """{"string": "value","number": 1,"boolean": True,"array": [],"map": {}}""",
-        "operation_tag": "test-operation-tag",
+        "destination_did": destination_did,
+        "message": json.dumps(message),
+        "operation_tag": operation_tag,
     }
 
-    # Send the POST request and print the response
-    json_response = post(endpoint, payload)
+    json_response = post("/create-verifiable-message", payload)
+
+    print("The response is as follows.\n")
     print(json_response)
+
+    print('\nPlease paste below to "verify_vc_message.py".\n')
+    pprint.pprint(json.loads(json_response), sort_dicts=False)
 
 
 if __name__ == "__main__":

--- a/examples/python/v2/cli/verify_vc_message.py
+++ b/examples/python/v2/cli/verify_vc_message.py
@@ -1,15 +1,48 @@
 from sock import post
+import json
+
+# PLEASE PASTE BELOW THE RESPONSE FROM "generate_vc_message.py".
+message = {
+    "issuer": {
+        "id": "did:nodex:test:DummyDummyDummyDummyDummyDummyDummyDummyDummyD"
+    },
+    "issuanceDate": "2024-03-22T11:43:47.741035+00:00",
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiableCredential"],
+    "credentialSubject": {
+        "container": {
+            "created_at": "2024-03-22T11:43:47.741035+00:00",
+            "destination_did": "did:nodex:test:DummyDummyDummyDummyDummyDummyDummyDummyDummyD",
+            "message_id": "d8b8bfbc-88ed-4d93-bfa5-a634e35d104e",
+            "payload": '{"message": {"string": '
+            '"value", "number": 1, '
+            '"boolean": true, "array": '
+            '["foo", "bar", "baz"], "map": '
+            '{"key": "value"}}}',
+            "project_hmac": "fc67f9f5c17ccd44ff3f8e270870c2b04f0980e22766b619a62f7c7ac4c95058",
+        }
+    },
+    "proof": {
+        "type": "EcdsaSecp256k1Signature2019",
+        "proofPurpose": "authentication",
+        "created": "2024-03-22T11:43:47.775189+00:00",
+        "verificationMethod": "did:nodex:test:DummyDummyDummyDummyDummyDummyDummyDummyDummyD#signingKey",
+        "jws": "eyJhbGciOiJFUzI1NksiLCJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdfQ..AnO3rmljCEHhbxvvLKxml8coj-JOwSSczlCxS7zfVBRy11AABM-aFBvwJKP32-VMESZnfF_EH0PZvkJSCAnqOg",
+        "controller": None,
+        "challenge": None,
+        "domain": None,
+    },
+}
 
 
 def main():
-    # The endpoint and payload you want to send
-    endpoint = "/verify-verifiable-message"
     payload = {
-        "message": """{"issuer":{"id":"did:nodex:test:EiDWAZgabmwyviEUcvPMssS_kJT1MUyhDO9iPdfx5dw5Xg"},"issuanceDate":"2024-03-04T17:05:39.042635+00:00","@context":["https://www.w3.org/2018/credentials/v1"],"type":["VerifiableCredential"],"credentialSubject":{"container":{"created_at":"2024-03-04T17:05:39.042635+00:00","destination_did":"did:nodex:test:EiBprXreMiba4loyl3psXm0RsECdtlCiQIjM8G9BtdQplA","message_id":"7cca38ee-77a6-4cfe-b7b4-5c0987fa1627","payload":"{\\"string\\": \\"value\\",\\"number\\": 1,\\"boolean\\": True,\\"array\\": [],\\"map\\": {}}","project_hmac":"b843ea611f2229cd645fdbe92c247c0887e5b2dcbed5f5fa75895bb553eee5dc"}},"proof":{"type":"EcdsaSecp256k1Signature2019","proofPurpose":"authentication","created":"2024-03-04T17:05:39.068522+00:00","verificationMethod":"did:nodex:test:EiDWAZgabmwyviEUcvPMssS_kJT1MUyhDO9iPdfx5dw5Xg#signingKey","jws":"eyJhbGciOiJFUzI1NksiLCJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdfQ.._iTjTfHLg78lJzGxwdFq5aT_b3xfNLaLBYybwD6ck8d34IN2a7gXuHIj-eJtUYzuTowNFAl5DGny8yKQMra7qA","controller":null,"challenge":null,"domain":null}}"""
+        "message": json.dumps(message),
     }
 
-    # Send the POST request and print the response
-    json_response = post(endpoint, payload)
+    json_response = post("/verify-verifiable-message", payload)
+
+    print("The response is as follows.\n")
     print(json_response)
 
 


### PR DESCRIPTION
## Why

The current `verify_vc_message.py` has the following issues.

- The JSON (payload) in the JSON must have two backslashes. The output of `generate_vc_message.py` has only one backslash, so the user must modify it to two to copy it and paste.


## What
Define individual JSON objects as python objects instead of the entire payload as a string.

In addition, the following fixes were made.

- Made explicit where the user has to modify

- Refactored the entire code

- made the output clearer

example
```
❯ python generate_vc_message.py                                                                                                                                                                                                                                 03/22 20:42:53
Now Requesting...
- Method: POST
- URL: http+unix:///Users/hirokiibuka/.nodex/run/nodex.sock:/create-verifiable-message

The response is as follows.

{
    "issuer": {
        "id": "did:nodex:test:EiD9aQYNUJMdgjeQetDj56LNzR6SdwhuXGFalvI3gugPHQ"
    },
    "issuanceDate": "2024-03-22T11:43:47.741035+00:00",
    "@context": [
        "https://www.w3.org/2018/credentials/v1"
    ],
    "type": [
        "VerifiableCredential"
    ],
    "credentialSubject": {
        "container": {
            "created_at": "2024-03-22T11:43:47.741035+00:00",
            "destination_did": "did:nodex:test:EiD9aQYNUJMdgjeQetDj56LNzR6SdwhuXGFalvI3gugPHQ",
            "message_id": "d8b8bfbc-88ed-4d93-bfa5-a634e35d104e",
            "payload": "{\"message\": {\"string\": \"value\", \"number\": 1, \"boolean\": true, \"array\": [\"foo\", \"bar\", \"baz\"], \"map\": {\"key\": \"value\"}}}",
            "project_hmac": "fc67f9f5c17ccd44ff3f8e270870c2b04f0980e22766b619a62f7c7ac4c95058"
        }
    },
    "proof": {
        "type": "EcdsaSecp256k1Signature2019",
        "proofPurpose": "authentication",
        "created": "2024-03-22T11:43:47.775189+00:00",
        "verificationMethod": "did:nodex:test:EiD9aQYNUJMdgjeQetDj56LNzR6SdwhuXGFalvI3gugPHQ#signingKey",
        "jws": "eyJhbGciOiJFUzI1NksiLCJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdfQ..AnO3rmljCEHhbxvvLKxml8coj-JOwSSczlCxS7zfVBRy11AABM-aFBvwJKP32-VMESZnfF_EH0PZvkJSCAnqOg",
        "controller": null,
        "challenge": null,
        "domain": null
    }
}

Please paste below to "verify_vc_message.py".

{'issuer': {'id': 'did:nodex:test:EiD9aQYNUJMdgjeQetDj56LNzR6SdwhuXGFalvI3gugPHQ'},
 'issuanceDate': '2024-03-22T11:43:47.741035+00:00',
 '@context': ['https://www.w3.org/2018/credentials/v1'],
 'type': ['VerifiableCredential'],
 'credentialSubject': {'container': {'created_at': '2024-03-22T11:43:47.741035+00:00',
                                     'destination_did': 'did:nodex:test:EiD9aQYNUJMdgjeQetDj56LNzR6SdwhuXGFalvI3gugPHQ',
                                     'message_id': 'd8b8bfbc-88ed-4d93-bfa5-a634e35d104e',
                                     'payload': '{"message": {"string": '
                                                '"value", "number": 1, '
                                                '"boolean": true, "array": '
                                                '["foo", "bar", "baz"], "map": '
                                                '{"key": "value"}}}',
                                     'project_hmac': 'fc67f9f5c17ccd44ff3f8e270870c2b04f0980e22766b619a62f7c7ac4c95058'}},
 'proof': {'type': 'EcdsaSecp256k1Signature2019',
           'proofPurpose': 'authentication',
           'created': '2024-03-22T11:43:47.775189+00:00',
           'verificationMethod': 'did:nodex:test:EiD9aQYNUJMdgjeQetDj56LNzR6SdwhuXGFalvI3gugPHQ#signingKey',
           'jws': 'eyJhbGciOiJFUzI1NksiLCJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdfQ..AnO3rmljCEHhbxvvLKxml8coj-JOwSSczlCxS7zfVBRy11AABM-aFBvwJKP32-VMESZnfF_EH0PZvkJSCAnqOg',
           'controller': None,
           'challenge': None,
           'domain': None}}

```

When this PR is merged, we plan to do the same for the other example code.