### PR TITLE
Add error handling to handlers of VC message

### DIFF
--- a/src/controllers/public/nodex_create_verifiable_message.rs
+++ b/src/controllers/public/nodex_create_verifiable_message.rs
@@ -41,6 +41,26 @@ pub async fn handler(
             CreateVerifiableMessageUseCaseError::DestinationNotFound => {
                 Ok(HttpResponse::NotFound().finish())
             }
+            CreateVerifiableMessageUseCaseError::BadRequest(message) => {
+                log::warn!("Bad Request: {}", message);
+                Ok(HttpResponse::BadRequest().body(message))
+            }
+            CreateVerifiableMessageUseCaseError::Unauthorized(message) => {
+                log::warn!("Unauthorized: {}", message);
+                Ok(HttpResponse::Unauthorized().body(message))
+            }
+            CreateVerifiableMessageUseCaseError::Forbidden(message) => {
+                log::warn!("Forbidden: {}", message);
+                Ok(HttpResponse::Forbidden().body(message))
+            }
+            CreateVerifiableMessageUseCaseError::NotFound(message) => {
+                log::warn!("NotFound: {}", message);
+                Ok(HttpResponse::NotFound().body(message))
+            }
+            CreateVerifiableMessageUseCaseError::Conflict(message) => {
+                log::warn!("Conflict: {}", message);
+                Ok(HttpResponse::Conflict().body(message))
+            }
             CreateVerifiableMessageUseCaseError::VCServiceFailed(e) => {
                 log::error!("{:?}", e);
                 Ok(HttpResponse::InternalServerError().finish())

--- a/src/controllers/public/nodex_verify_verifiable_message.rs
+++ b/src/controllers/public/nodex_verify_verifiable_message.rs
@@ -43,6 +43,26 @@ pub async fn handler(
                 log::error!("{:?}", e);
                 Ok(HttpResponse::InternalServerError().finish())
             }
+            VerifyVerifiableMessageUseCaseError::BadRequest(message) => {
+                log::warn!("Bad Request: {}", message);
+                Ok(HttpResponse::BadRequest().body(message))
+            }
+            VerifyVerifiableMessageUseCaseError::Unauthorized(message) => {
+                log::warn!("Unauthorized: {}", message);
+                Ok(HttpResponse::Unauthorized().body(message))
+            }
+            VerifyVerifiableMessageUseCaseError::Forbidden(message) => {
+                log::warn!("Forbidden: {}", message);
+                Ok(HttpResponse::Forbidden().body(message))
+            }
+            VerifyVerifiableMessageUseCaseError::NotFound(message) => {
+                log::warn!("NotFound: {}", message);
+                Ok(HttpResponse::NotFound().body(message))
+            }
+            VerifyVerifiableMessageUseCaseError::Conflict(message) => {
+                log::warn!("Conflict: {}", message);
+                Ok(HttpResponse::Conflict().body(message))
+            }
             VerifyVerifiableMessageUseCaseError::Other(e) => {
                 log::error!("{:?}", e);
                 Ok(HttpResponse::InternalServerError().finish())

--- a/src/usecase/verifiable_message_usecase.rs
+++ b/src/usecase/verifiable_message_usecase.rs
@@ -43,6 +43,16 @@ pub enum CreateVerifiableMessageUseCaseError {
     DestinationNotFound,
     #[error(transparent)]
     VCServiceFailed(#[from] DIDVCServiceError),
+    #[error("bad request: {0}")]
+    BadRequest(String),
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("conflict: {0}")]
+    Conflict(String),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -55,6 +65,16 @@ pub enum VerifyVerifiableMessageUseCaseError {
     NotAddressedToMe,
     #[error(transparent)]
     VCServiceFailed(#[from] DIDVCServiceError),
+    #[error("bad request: {0}")]
+    BadRequest(String),
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("conflict: {0}")]
+    Conflict(String),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -97,7 +117,27 @@ impl VerifiableMessageUseCase {
                 occurred_at: now,
             })
             .await
-            .context("failed to add create activity")?;
+            .map_err(|e| match e {
+                MessageActivityHttpError::BadRequest(message) => {
+                    CreateVerifiableMessageUseCaseError::BadRequest(message)
+                }
+                MessageActivityHttpError::Unauthorized(message) => {
+                    CreateVerifiableMessageUseCaseError::Unauthorized(message)
+                }
+                MessageActivityHttpError::Forbidden(message) => {
+                    CreateVerifiableMessageUseCaseError::Forbidden(message)
+                }
+                MessageActivityHttpError::NotFound(message) => {
+                    CreateVerifiableMessageUseCaseError::NotFound(message)
+                }
+                MessageActivityHttpError::Conflict(message) => {
+                    CreateVerifiableMessageUseCaseError::Conflict(message)
+                }
+                _ => CreateVerifiableMessageUseCaseError::Other(e.into()),
+            })?;
+
+        // Discard the unused result
+        let _ = result;
 
         Ok(result)
     }
@@ -140,7 +180,24 @@ impl VerifiableMessageUseCase {
                     status: VerifiedStatus::Valid,
                 })
                 .await
-                .context("failed to add verify activity")?;
+                .map_err(|e| match e {
+                    MessageActivityHttpError::BadRequest(message) => {
+                        VerifyVerifiableMessageUseCaseError::BadRequest(message)
+                    }
+                    MessageActivityHttpError::Unauthorized(message) => {
+                        VerifyVerifiableMessageUseCaseError::Unauthorized(message)
+                    }
+                    MessageActivityHttpError::Forbidden(message) => {
+                        VerifyVerifiableMessageUseCaseError::Forbidden(message)
+                    }
+                    MessageActivityHttpError::NotFound(message) => {
+                        VerifyVerifiableMessageUseCaseError::NotFound(message)
+                    }
+                    MessageActivityHttpError::Conflict(message) => {
+                        VerifyVerifiableMessageUseCaseError::Conflict(message)
+                    }
+                    _ => VerifyVerifiableMessageUseCaseError::Other(e.into()),
+                })?;
             Ok(vc)
         } else {
             self.message_activity_repository
@@ -152,7 +209,24 @@ impl VerifiableMessageUseCase {
                     status: VerifiedStatus::Invalid,
                 })
                 .await
-                .context("failed to add verify activity")?;
+                .map_err(|e| match e {
+                    MessageActivityHttpError::BadRequest(message) => {
+                        VerifyVerifiableMessageUseCaseError::BadRequest(message)
+                    }
+                    MessageActivityHttpError::Unauthorized(message) => {
+                        VerifyVerifiableMessageUseCaseError::Unauthorized(message)
+                    }
+                    MessageActivityHttpError::Forbidden(message) => {
+                        VerifyVerifiableMessageUseCaseError::Forbidden(message)
+                    }
+                    MessageActivityHttpError::NotFound(message) => {
+                        VerifyVerifiableMessageUseCaseError::NotFound(message)
+                    }
+                    MessageActivityHttpError::Conflict(message) => {
+                        VerifyVerifiableMessageUseCaseError::Conflict(message)
+                    }
+                    _ => VerifyVerifiableMessageUseCaseError::Other(e.into()),
+                })?;
             Err(VerifyVerifiableMessageUseCaseError::VerificationFailed)
         }
     }
@@ -427,7 +501,7 @@ pub mod tests {
                 .generate(destination_did, message, "test".to_string(), now)
                 .await;
 
-            if let Err(CreateVerifiableMessageUseCaseError::Other(_)) = generated {
+            if let Err(CreateVerifiableMessageUseCaseError::BadRequest(_)) = generated {
             } else {
                 panic!("unexpected result: {:?}", generated);
             }


### PR DESCRIPTION
## What

Expanded implimentation of error handling added in this PR to the handlers of VC Message.
https://github.com/nodecross/nodex/pull/281


## Check
1. generate vc message by example code.
2. delete vc message from DB.
3. verify vc message by example code.
4. the result is below.

```
❯ python verify_vc_message.py                                   
Now Requesting...
- Method: POST
- URL: http+unix:///Users/hirokiibuka/.nodex/run/nodex.sock:/verify-verifiable-message

The response is as follows.

404 Not Found "Message Activity ID not found"

```
