### PR TITLE
fix kill other processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chacha20"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,7 +2631,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4863ee94f19ed315bf3bc00299338d857d4b5bc856af375cc97d237382ad3856"
 dependencies = [
- "nix",
+ "nix 0.23.2",
  "winapi",
 ]
 
@@ -2697,6 +2703,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodex"
 version = "2.0.2"
 dependencies = [
@@ -2730,6 +2748,7 @@ dependencies = [
  "libloading",
  "log",
  "mac_address",
+ "nix 0.28.0",
  "qstring",
  "reqwest",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,6 +1202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,6 +2731,7 @@ dependencies = [
  "clap",
  "colored",
  "cuid",
+ "daemonize",
  "data-encoding",
  "didcomm-rs",
  "digest 0.10.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ anyhow = "1.0.81"
 thiserror = "1.0.58"
 sysinfo = "0.30.8"
 nix = { version = "0.28.0", features = ["signal"] }
+daemonize = "0.5.0"
 
 [dev-dependencies]
 rstest = { version = "0.18.2" }

--- a/examples/python/v2/cli/version_update.py
+++ b/examples/python/v2/cli/version_update.py
@@ -2,8 +2,10 @@ from sock import post
 
 
 payload = {
-    "binary_url": "https://example.com/nodex-agent-1.0.0.zip",
-    "path": "/tmp",
+    "message": {
+        "binary_url": "http://example.com/nodex-agent-1.0.0.zip",
+        "path": "/tmp",
+    }
 }
 
 json_response = post("/internal/version/update", payload)

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,19 +383,17 @@ fn kill_other_self_process() {
 
             for process in system.processes_by_exact_name("nodex-agent") {
                 if current_pid == process.pid() {
-                    log::info!("Skipping current process with PID: {:?}", process.pid());
                     continue;
                 }
                 if process.parent() == Some(current_pid) {
-                    log::info!("Skipping child process with PID: {:?}", process.pid());
                     continue;
                 }
 
                 let pid_as_i32 = process.pid().as_u32() as i32;
                 match kill(Pid::from_raw(pid_as_i32), Signal::SIGTERM) {
-                    Ok(_) => log::info!("Process with PID: {} killed successfully.", pid_as_i32),
+                    Ok(_) => log::info!("nodex Process with PID: {} killed successfully.", pid_as_i32),
                     Err(e) => log::error!(
-                        "Failed to kill process with PID: {}. Error: {}",
+                        "Failed to kill nodex process with PID: {}. Error: {}",
                         pid_as_i32,
                         e
                     ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,26 +383,27 @@ fn kill_other_self_process() {
 
             for process in system.processes_by_exact_name("nodex-agent") {
                 if current_pid == process.pid() {
-                    println!("Skipping current process with PID: {:?}", process.pid());
+                    log::info!("Skipping current process with PID: {:?}", process.pid());
                     continue;
                 }
                 if process.parent() == Some(current_pid) {
-                    println!("Skipping child process with PID: {:?}", process.pid());
+                    log::info!("Skipping child process with PID: {:?}", process.pid());
                     continue;
                 }
 
                 let pid_as_i32 = process.pid().as_u32() as i32;
                 match kill(Pid::from_raw(pid_as_i32), Signal::SIGTERM) {
-                    Ok(_) => println!("Process with PID: {} killed successfully.", pid_as_i32),
-                    Err(e) => println!(
+                    Ok(_) => log::info!("Process with PID: {} killed successfully.", pid_as_i32),
+                    Err(e) => log::error!(
                         "Failed to kill process with PID: {}. Error: {}",
-                        pid_as_i32, e
+                        pid_as_i32,
+                        e
                     ),
                 };
             }
         }
         Err(e) => {
-            println!("Failed to get current PID: {:?}", e);
+            log::error!("Failed to get current PID: {:?}", e);
             panic!()
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,7 +394,10 @@ fn kill_other_self_process() {
                 let pid_as_i32 = process.pid().as_u32() as i32;
                 match kill(Pid::from_raw(pid_as_i32), Signal::SIGTERM) {
                     Ok(_) => println!("Process with PID: {} killed successfully.", pid_as_i32),
-                    Err(e) => println!("Failed to kill process with PID: {}. Error: {}", pid_as_i32, e),
+                    Err(e) => println!(
+                        "Failed to kill process with PID: {}. Error: {}",
+                        pid_as_i32, e
+                    ),
                 };
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,7 +391,10 @@ fn kill_other_self_process() {
 
                 let pid_as_i32 = process.pid().as_u32() as i32;
                 match kill(Pid::from_raw(pid_as_i32), Signal::SIGTERM) {
-                    Ok(_) => log::info!("nodex Process with PID: {} killed successfully.", pid_as_i32),
+                    Ok(_) => log::info!(
+                        "nodex Process with PID: {} killed successfully.",
+                        pid_as_i32
+                    ),
                     Err(e) => log::error!(
                         "Failed to kill nodex process with PID: {}. Error: {}",
                         pid_as_i32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,10 @@ use dotenvy::dotenv;
 use handlers::Command;
 use handlers::MqttClient;
 use mac_address::get_mac_address;
+use nix::{
+    sys::signal::{kill, Signal},
+    unistd::Pid,
+};
 use rumqttc::{AsyncClient, MqttOptions, QoS};
 use services::nodex::NodeX;
 use services::studio::Studio;
@@ -13,6 +17,7 @@ use shadow_rs::shadow;
 use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{collections::HashMap, fs, sync::Arc};
+use sysinfo::{get_current_pid, System};
 use tokio::sync::mpsc;
 use tokio::sync::Notify;
 use tokio::sync::RwLock;

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,21 +378,28 @@ fn log_init() {
 fn kill_other_self_process() {
     match get_current_pid() {
         Ok(current_pid) => {
-            let system = System::new_all();
+            let mut system = System::new_all();
+            system.refresh_all();
+
             for process in system.processes_by_exact_name("nodex-agent") {
                 if current_pid == process.pid() {
+                    println!("Skipping current process with PID: {:?}", process.pid());
                     continue;
                 }
+                if process.parent() == Some(current_pid) {
+                    println!("Skipping child process with PID: {:?}", process.pid());
+                    continue;
+                }
+
                 let pid_as_i32 = process.pid().as_u32() as i32;
-                let pid = Pid::from_raw(pid_as_i32);
-                match kill(pid, Signal::SIGTERM) {
-                    Ok(_) => log::info!("Process with PID: {} killed successfully.", pid),
-                    Err(e) => log::error!("Failed to kill process with PID: {}. Error: {}", pid, e),
+                match kill(Pid::from_raw(pid_as_i32), Signal::SIGTERM) {
+                    Ok(_) => println!("Process with PID: {} killed successfully.", pid_as_i32),
+                    Err(e) => println!("Failed to kill process with PID: {}. Error: {}", pid_as_i32, e),
                 };
             }
         }
         Err(e) => {
-            log::error!("{:?}", e);
+            println!("Failed to get current PID: {:?}", e);
             panic!()
         }
     }

--- a/src/services/nodex.rs
+++ b/src/services/nodex.rs
@@ -10,6 +10,7 @@ use crate::{
     repository::did_repository::DidRepository,
 };
 
+use daemonize::Daemonize;
 use reqwest::StatusCode;
 use serde::Deserialize;
 use std::{fs, io::Cursor, path::PathBuf, process::Command};
@@ -149,7 +150,12 @@ impl NodeX {
         zip_extract::extract(Cursor::new(content), &target_dir, true)?;
 
         Command::new("chmod").arg("+x").arg(&agent_path).status()?;
-        Command::new(&agent_path).spawn()?;
+
+        let daemonize = Daemonize::new();
+        daemonize.start().expect("Failed to update nodex process");
+        let child = std::process::Command::new(&agent_path)
+            .spawn()
+            .expect("Failed to execute command");
 
         Ok(())
     }

--- a/src/services/nodex.rs
+++ b/src/services/nodex.rs
@@ -153,7 +153,7 @@ impl NodeX {
 
         let daemonize = Daemonize::new();
         daemonize.start().expect("Failed to update nodex process");
-        let child = std::process::Command::new(&agent_path)
+        std::process::Command::new(&agent_path)
             .spawn()
             .expect("Failed to execute command");
 


### PR DESCRIPTION
When run on Debian, the process terminates and crashes, displaying "terminated".

This was done because the process works fine on macOS and Windows. The problem was due to clone3 being issued multiple times when running the process on Debian, so the process was dropped with terminated at runtime.

The changes include
- Changed to skip processes with the same parent PID
- Changed to make the parent process different by deamonize at the point where it is started by spawn
- Fixed a flaw in example
