### PR TITLE
fix zip example on release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
         uses: ./.github/actions/upload-release-asset
         with:
           release_id: ${{ steps.release.outputs.result }}
-          asset_path: ./examples/nodejs/example.zip
+          asset_path: ./examples/example.zip
           asset_name: example.zip
           asset_content_type: application/zip
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,10 +109,9 @@ jobs:
 
       - name: Create Example asset
         shell: bash
-        working-directory: examples/nodejs
+        working-directory: examples
         run: |
-          mv app/README.md .
-          zip -r example.zip app/ README.md package.json tsconfig.json yarn.lock ../../LICENSE
+          zip -r example.zip nodejs/ python/ systemd/ ../../LICENSE
 
       - name: Create Release
         uses: actions/github-script@v5


### PR DESCRIPTION
In previous versions, nodejs example was zipped as the target, but the directory structure has changed and python has been added.
We have adapted to those changes.