### PR TITLE
Add validation to custom_metrics

### DIFF
--- a/src/controllers/public/send_custom_metric.rs
+++ b/src/controllers/public/send_custom_metric.rs
@@ -18,6 +18,10 @@ pub async fn handler(
     _req: HttpRequest,
     web::Json(json): web::Json<MessageContainer>,
 ) -> actix_web::Result<HttpResponse> {
+    if json.key.is_empty() {
+        return Ok(HttpResponse::BadRequest().json("key is required"));
+    }
+
     let occurred_at = match json.occurred_at.parse::<i64>() {
         Ok(timestamp) => match DateTime::from_timestamp(timestamp, 0) {
             Some(dt) => dt,
@@ -31,12 +35,21 @@ pub async fn handler(
     };
 
     let usecase = CustomMetricUsecase::new();
-    usecase
+    match usecase
         .save(CustomMetricStoreRequest {
             key: json.key,
             value: json.value,
             occurred_at,
         })
-        .await;
-    Ok(HttpResponse::NoContent().finish())
+        .await
+    {
+        Ok(_) => {
+            log::info!("sent custom metrics");
+            Ok(HttpResponse::NoContent().finish())
+        }
+        Err(e) => {
+            log::error!("{:?}", e);
+            Ok(HttpResponse::InternalServerError().json("internal server error"))
+        }
+    }
 }

--- a/src/repository/custom_metric_repository.rs
+++ b/src/repository/custom_metric_repository.rs
@@ -10,5 +10,5 @@ pub struct CustomMetricStoreRequest {
 
 #[async_trait::async_trait]
 pub trait CustomMetricStoreRepository {
-    async fn save(&self, request: CustomMetricStoreRequest) -> anyhow::Result<()>;
+    async fn save(&self, request: CustomMetricStoreRequest) -> anyhow::Result<(), anyhow::Error>;
 }

--- a/src/repository/custom_metric_repository.rs
+++ b/src/repository/custom_metric_repository.rs
@@ -10,5 +10,5 @@ pub struct CustomMetricStoreRequest {
 
 #[async_trait::async_trait]
 pub trait CustomMetricStoreRepository {
-    async fn save(&self, request: CustomMetricStoreRequest) -> anyhow::Result<(), anyhow::Error>;
+    async fn save(&self, request: CustomMetricStoreRequest) -> anyhow::Result<()>;
 }

--- a/src/repository/event_repository.rs
+++ b/src/repository/event_repository.rs
@@ -10,5 +10,5 @@ pub struct EventStoreRequest {
 
 #[async_trait::async_trait]
 pub trait EventStoreRepository {
-    async fn save(&self, request: EventStoreRequest) -> anyhow::Result<(), anyhow::Error>;
+    async fn save(&self, request: EventStoreRequest) -> anyhow::Result<()>;
 }

--- a/src/usecase/custom_metric_usecase.rs
+++ b/src/usecase/custom_metric_usecase.rs
@@ -14,7 +14,7 @@ impl CustomMetricUsecase {
         }
     }
 
-    pub async fn save(&self, request: CustomMetricStoreRequest) -> Result<(), anyhow::Error> {
+    pub async fn save(&self, request: CustomMetricStoreRequest) -> anyhow::Result<()> {
         if let Err(e) = self.repository.save(request).await {
             log::error!("{:?}", e);
             Err(e)

--- a/src/usecase/custom_metric_usecase.rs
+++ b/src/usecase/custom_metric_usecase.rs
@@ -14,10 +14,13 @@ impl CustomMetricUsecase {
         }
     }
 
-    pub async fn save(&self, request: CustomMetricStoreRequest) {
-        match self.repository.save(request).await {
-            Ok(_) => log::info!("save event"),
-            Err(e) => log::error!("{:?}", e),
+    pub async fn save(&self, request: CustomMetricStoreRequest) -> Result<(), anyhow::Error> {
+        if let Err(e) = self.repository.save(request).await {
+            log::error!("{:?}", e);
+            Err(e)
+        } else {
+            log::info!("save custom metrics");
+            Ok(())
         }
     }
 }
@@ -45,12 +48,15 @@ mod tests {
         let usecase = CustomMetricUsecase {
             repository: Box::new(MockCustomMetricStoreRepository {}),
         };
-        usecase
-            .save(CustomMetricStoreRequest {
-                key: "test_key".to_string(),
-                value: 10.52,
-                occurred_at: chrono::Utc::now(),
-            })
-            .await;
+
+        let request = CustomMetricStoreRequest {
+            key: "test_key".to_string(),
+            value: 10.52,
+            occurred_at: chrono::Utc::now(),
+        };
+
+        if let Err(e) = usecase.save(request).await {
+            panic!("{:?}", e);
+        }
     }
 }

--- a/src/usecase/event_usecase.rs
+++ b/src/usecase/event_usecase.rs
@@ -14,7 +14,7 @@ impl EventUsecase {
         }
     }
 
-    pub async fn save(&self, request: EventStoreRequest) -> Result<(), anyhow::Error> {
+    pub async fn save(&self, request: EventStoreRequest) -> anyhow::Result<()> {
         match self.repository.save(request).await {
             Ok(_) => {
                 log::info!("save event");


### PR DESCRIPTION
## Changes
Return 400 error when key is an empty string

## Sample outputs
```
 ~/r/c/nodex   feature/custom-metrics-key-validation *$…  examples/python  ./venv/bin/python src/generate_custom_metric.py
Now Requesting...
- Method: POST
- URL: http+unix:///Users/xxx/.nodex/run/nodex.sock:/custom_metrics

The response is as follows.

400 Bad Request "key is required"
```