### PR TITLE
fix: use OS CA certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,11 +1926,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls 0.23.10",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2951,6 +2951,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.10",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -2964,7 +2965,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -4021,15 +4021,6 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ nodex-didcomm = { git = "https://github.com/nodecross/nodex-didcomm", tag = "0.1
 qstring = { version = "0.7.2" }
 reqwest = { version = "0.12", features = [
     "json",
-    "rustls-tls",
+    "rustls-tls-native-roots",
 ], default-features = false }
 rumqttc = { version = "0.24.0" }
 scrypt = { version = "0.11.0", features = ["simple"] }


### PR DESCRIPTION
## WHY
- rustls does not use OS CA Cert.
- This causes inconvenience when using https proxy with ssl bump.
  - Users must add CA Cert manually.

## WHAT
- Make rustls use OS CA Cert.

## NOTE
- There is test with proxy. 
  - https://github.com/nodecross/nodex/tree/feat/proxy-test/test_resource/vagrant
-  Not tested on macOS.