### PR TITLE
fix: add trait bounds directly to a trait

### DIFF
--- a/src/repository/metric_repository.rs
+++ b/src/repository/metric_repository.rs
@@ -14,7 +14,7 @@ pub struct MetricsWithTimestamp {
     pub metrics: Vec<Metric>,
 }
 
-pub trait MetricsWatchRepository {
+pub trait MetricsWatchRepository: Send + Sync + 'static {
     fn watch_metrics(&mut self) -> Vec<Metric>;
 }
 
@@ -26,7 +26,7 @@ pub trait MetricsCacheRepository {
 }
 
 #[async_trait::async_trait]
-pub trait MetricStoreRepository {
+pub trait MetricStoreRepository: Send + Sync + 'static {
     async fn save(&self, request: Vec<MetricsWithTimestamp>) -> anyhow::Result<()>;
 }
 

--- a/src/usecase/metric_usecase.rs
+++ b/src/usecase/metric_usecase.rs
@@ -8,8 +8,8 @@ use tokio::sync::Mutex as TokioMutex;
 use tokio::sync::Notify;
 
 pub struct MetricUsecase {
-    store_repository: Box<dyn MetricStoreRepository + Send + Sync + 'static>,
-    watch_repository: Box<dyn MetricsWatchRepository + Send + Sync + 'static>,
+    store_repository: Box<dyn MetricStoreRepository>,
+    watch_repository: Box<dyn MetricsWatchRepository>,
     config: Box<SingletonAppConfig>,
     cache_repository: Arc<TokioMutex<MetricsInMemoryCacheService>>,
     shutdown_notify: Arc<Notify>,
@@ -17,8 +17,8 @@ pub struct MetricUsecase {
 
 impl MetricUsecase {
     pub fn new(
-        store_repository: Box<dyn MetricStoreRepository + Send + Sync>,
-        watch_repository: Box<dyn MetricsWatchRepository + Send + Sync>,
+        store_repository: Box<dyn MetricStoreRepository>,
+        watch_repository: Box<dyn MetricsWatchRepository>,
         config: Box<SingletonAppConfig>,
         cache_repository: Arc<TokioMutex<MetricsInMemoryCacheService>>,
         shutdown_notify: Arc<Notify>,


### PR DESCRIPTION
There are two ways to add trait bounds: directly to a trait, and by using them in the context of a struct's fields.
In the current implementation, trait bounds are added to the struct's fields.
However, there are inconsistencies in notation between the struct's fields and the arguments of the new method.
Therefore, I changed the way to add trait bounds from the context of the struct's fields to directly to a trait.
