### PR TITLE
chore: faster installation for taplo

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -21,8 +21,9 @@ runs:
         cargo clippy -- -D warnings
 
     - name: (check) install-taplo
-      shell: bash
-      run: cargo install --locked taplo-cli
+      uses: taiki-e/install-action@v2
+      with:
+        tool: taplo-cli
 
     - name: (check) lint-toml
       shell: bash


### PR DESCRIPTION
Make the installation of taplo-cli faster using the taiki-e/install-action action, which utilizes cargo binstall.