### PR TITLE
feat: implement size-limited JSON requests for save metrics

### DIFF
--- a/agent/src/repository/metric_repository.rs
+++ b/agent/src/repository/metric_repository.rs
@@ -34,6 +34,7 @@ pub trait MetricStoreRepository {
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum MetricType {
     CpuUsage,
     MemoryUsage,

--- a/agent/src/services/studio.rs
+++ b/agent/src/services/studio.rs
@@ -424,6 +424,9 @@ impl MetricStoreRepository for Studio {
 
             while let Some(m) = metrics.pop_front() {
                 let item_size = serde_json::to_string(&m)?.len();
+                if item_size > JSON_BODY_MAX_SIZE {
+                    anyhow::bail!("invalid item size: JSON body size too large")
+                }
                 if current_size + item_size > JSON_BODY_MAX_SIZE {
                     metrics.push_front(m);
                     break;


### PR DESCRIPTION
During NodeX Studio's maintenance mode, the NodeX agent caches metrics in a VecDeque structure.
Once NodeX Studio becomes available again, the agent resumes sending these cached metrics.
However, there's a potential issue where the agent's cache size may exceed the maximum allowable size for JSON requests to NodeX Studio.

To address this, this PR implements a solution that creates size-limited JSON request chunks.
This approach ensures that all metrics are successfully transmitted, regardless of the cache size, by breaking down large data sets into manageable portions.