### PR TITLE
Feature/stdout error messages for nodejs example codes

### DIFF
--- a/examples/nodejs/src/lib/sock.js
+++ b/examples/nodejs/src/lib/sock.js
@@ -8,26 +8,35 @@ const call = async (method, path, json) => {
   let response;
   const URL = [base, path].join(":");
   console.log(`calling ${method} ${URL}`);
-  switch (method) {
-    case "get":
-      response = await got
-        .get(URL, {
-          enableUnixSockets: true,
-        })
-        .json();
-      break;
-    case "post":
-      response = await got
-        .post(URL, {
-          enableUnixSockets: true,
-          json,
-        })
-        .json();
-      break;
-    default:
-      throw new Error(`Unsupported method: ${method}`);
+
+  try {
+    switch (method) {
+      case "get":
+        response = await got
+          .get(URL, {
+            enableUnixSockets: true,
+          })
+          .json();
+        break;
+      case "post":
+        response = await got
+          .post(URL, {
+            enableUnixSockets: true,
+            json,
+          })
+          .json();
+        break;
+      default:
+        throw new Error(`Unsupported method: ${method}`);
+    }
+    return JSON.stringify(response, null, 4);
+  } catch (error) {
+    console.error("Error in API call:", error.message);
+    if (error.response) {
+      console.error("Error response:", error.response.body);
+    }
+    throw error;
   }
-  return JSON.stringify(response, null, 4);
 };
 
 export const get = async (path) => call("get", path, null);


### PR DESCRIPTION
## Description
Add try catch to capture error response in nodejs example codes

##

### Before
```
calling post unix:/Users/andrew/.nodex/run/nodex.sock:/custom_metrics
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

HTTPError: Response code 400 (Bad Request)
```

### After
```
calling post unix:/Users/andrew/.nodex/run/nodex.sock:/custom_metrics
Error in API call: Response code 400 (Bad Request)
Error response: Json deserialize error: invalid type: integer `1732080288808`, expected a string at line 1 column 59
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

HTTPError: Response code 400 (Bad Request)
```