### PR TITLE
feat: sign on workflow dispatch for verification

### DIFF
--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -1,0 +1,53 @@
+name: Sign binary by cosign
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sign:
+    name: sign by cosign
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign the binary using OIDC
+        run: |
+          cosign sign-blob \
+            --yes \
+            --oidc-issuer "https://token.actions.githubusercontent.com" \
+            --oidc-client-id "sigstore" \
+            --bundle nodex.bundle \
+            target/release/nodex
+
+      - name: Upload artifact (binary)
+        uses: actions/upload-artifact@v4
+        with:
+          name: nodex
+          path: target/release/nodex
+
+      - name: Upload artifact (signature bundle)
+        uses: actions/upload-artifact@v4
+        with:
+          path: nodex.bundle
+          name: nodex.bundle

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -19,11 +19,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build release binary
         run: cargo build --release --locked


### PR DESCRIPTION
This is a verification workflow for implementing signature verification.
It actually signs the binary by cosign and outputs the generated bundle and binary.