### PR TITLE
refactor: update nodex find identifier handler to use Uri

### DIFF
--- a/agent/src/controllers/public/nodex_find_identifier.rs
+++ b/agent/src/controllers/public/nodex_find_identifier.rs
@@ -11,8 +11,8 @@ use std::str::FromStr;
 
 pub async fn handler(uri: Uri) -> Result<Json<Option<DidDocument>>, AgentErrorCode> {
     let raw_path = uri.path();
-    let did = if raw_path.starts_with("/identifiers/") {
-        &raw_path[13..]
+    let did = if let Some(stripped) = raw_path.strip_prefix("/identifiers/") {
+        stripped
     } else {
         return Err(AgentErrorCode::FindIdentifierInternal)?;
     };
@@ -21,7 +21,7 @@ pub async fn handler(uri: Uri) -> Result<Json<Option<DidDocument>>, AgentErrorCo
         .map_err(|_| AgentErrorCode::FindIdentifierInternal)?;
     let datastore = DidWebvhDataStoreImpl::new(baseurl.clone());
     let mut service = DidWebvhServiceImpl::new(datastore);
-    let did = Did::from_str(&did).map_err(|_| AgentErrorCode::FindIdentifierInternal)?;
+    let did = Did::from_str(did).map_err(|_| AgentErrorCode::FindIdentifierInternal)?;
     match service.resolve_identifier(&did).await {
         Ok(v) => Ok(Json(v)),
         Err(e) => {

--- a/agent/src/controllers/public/nodex_find_identifier.rs
+++ b/agent/src/controllers/public/nodex_find_identifier.rs
@@ -1,14 +1,21 @@
 use crate::controllers::errors::AgentErrorCode;
 use crate::nodex::utils::webvh_client::DidWebvhDataStoreImpl;
 use crate::server_config;
-use axum::extract::{Json, Path};
+use axum::extract::Json;
+use axum::http::Uri;
 use protocol::did_webvh::domain::did::Did;
 use protocol::did_webvh::domain::did_document::DidDocument;
 use protocol::did_webvh::service::resolver::resolver_service::DidWebvhResolverService;
 use protocol::did_webvh::service::service_impl::DidWebvhServiceImpl;
 use std::str::FromStr;
 
-pub async fn handler(Path(did): Path<String>) -> Result<Json<Option<DidDocument>>, AgentErrorCode> {
+pub async fn handler(uri: Uri) -> Result<Json<Option<DidDocument>>, AgentErrorCode> {
+    let raw_path = uri.path();
+    let did = if raw_path.starts_with("/identifiers/") {
+        &raw_path[13..]
+    } else {
+        return Err(AgentErrorCode::FindIdentifierInternal)?;
+    };
     let server_config = server_config();
     let baseurl = url::Url::parse(&server_config.did_http_endpoint())
         .map_err(|_| AgentErrorCode::FindIdentifierInternal)?;


### PR DESCRIPTION
localhost%3A8000:webvh:v1:uuid などのDID パスが渡された際にaxum の方で解釈が入ってしまい, localhost:8000:webvh:v1:uuid という形式になるため後続のDID のパス変換処理で不具合が生じるためuri からPath を抽出する方法に改修した